### PR TITLE
Modifiers / Padding

### DIFF
--- a/src/elements/modifiers/Paddings/Paddings.css
+++ b/src/elements/modifiers/Paddings/Paddings.css
@@ -1,0 +1,140 @@
+:root {
+
+  /* CSS variables */
+  --padding-small: 8px;
+  --padding-medium: 16px;
+  --padding-large: 48px;
+}
+
+.padding {
+
+  /* Size variants */
+  &--small {
+    padding: var(--padding-small);
+
+    @media (--medium) { padding: calc(var(--padding-small) * 2); }
+  }
+
+  &--medium {
+    padding: var(--padding-medium);
+
+    @media (--medium) { padding: calc(var(--padding-medium) * 2); }
+  }
+
+  &--large {
+    padding: var(--padding-large);
+
+    @media (--medium) { padding: calc(var(--padding-large) * 2); }
+  }
+
+  &--extra-large {
+    padding: calc(var(--padding-large) * 2);
+
+    @media (--medium) { padding: calc(var(--padding-large) * 4); }
+  }
+
+  /* Side variants */
+  &--small {
+    &-top {
+      padding-top: var(--padding-small);
+
+      @media (--medium) { padding-top: var(--padding-medium); }
+    }
+
+    &-right {
+      padding-right: var(--padding-small);
+
+      @media (--medium) { padding-right: var(--padding-medium); }
+    }
+
+    &-bottom {
+      padding-bottom: var(--padding-small);
+
+      @media (--medium) { padding-bottom: var(--padding-medium); }
+    }
+
+    &-left {
+      padding-left: var(--padding-small);
+
+      @media (--medium) { padding-left: var(--padding-medium); }
+    }
+  }
+
+  &--medium {
+    &-top {
+      padding-top: var(--padding-medium);
+
+      @media (--medium) { padding-top: calc(var(--padding-medium) * 2); }
+    }
+
+    &-right {
+      padding-right: var(--padding-medium);
+
+      @media (--medium) { padding-right: calc(var(--padding-medium) * 2); }
+    }
+
+    &-bottom {
+      padding-bottom: var(--padding-medium);
+
+      @media (--medium) { padding-bottom: calc(var(--padding-medium) * 2); }
+    }
+
+    &-left {
+      padding-left: var(--padding-medium);
+
+      @media (--medium) { padding-left: calc(var(--padding-medium) * 2); }
+    }
+  }
+
+  &--large {
+    &-top {
+      padding-top: var(--padding-large);
+
+      @media (--medium) { padding-top: calc(var(--padding-large) * 2); }
+    }
+
+    &-right {
+      padding-right: var(--padding-large);
+
+      @media (--medium) { padding-right: calc(var(--padding-large) * 2); }
+    }
+
+    &-bottom {
+      padding-bottom: var(--padding-large);
+
+      @media (--medium) { padding-bottom: calc(var(--padding-large) * 2); }
+    }
+
+    &-left {
+      padding-left: var(--padding-large);
+
+      @media (--medium) { padding-left: calc(var(--padding-large) * 2); }
+    }
+  }
+
+  &--extra-large {
+    &-top {
+      padding-top: calc(var(--padding-large) * 2);
+
+      @media (--medium) { padding-top: calc(var(--padding-large) * 4); }
+    }
+
+    &-right {
+      padding-right: calc(var(--padding-large) * 2);
+
+      @media (--medium) { padding-right: calc(var(--padding-large) * 4); }
+    }
+
+    &-bottom {
+      padding-bottom: calc(var(--padding-large) * 2);
+
+      @media (--medium) { padding-bottom: calc(var(--padding-large) * 4); }
+    }
+
+    &-left {
+      padding-left: calc(var(--padding-large) * 2);
+
+      @media (--medium) { padding-left: calc(var(--padding-large) * 4); }
+    }
+  }
+}

--- a/src/elements/modifiers/Paddings/Paddings.example.jsx
+++ b/src/elements/modifiers/Paddings/Paddings.example.jsx
@@ -1,0 +1,60 @@
+/*
+  OPTIONS:
+  The following options are available for Component examples:
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
+
+  Example:
+    ```
+      examples: [{
+        name: 'Default styling',
+        component: (
+          <Component>Lorem ipsum</Component>
+        ),
+        options: {
+          padding: '1rem',
+          background: 'path/or/url/to/image(.jpg|.gif|.png|.svg)',
+          brightness: 0.5,
+        }
+      },
+    ```
+*/
+
+export default [{
+  examples: [
+    {
+      name: 'Small padding',
+      description: '',
+      staticPath: '',
+      component: (
+        <div className="padding--small">{Utils.ipsum('paragraph', 2)}</div>
+      ),
+      notes: ''
+    }, {
+      name: 'Medium padding',
+      description: '',
+      staticPath: '',
+      component: (
+        <div className="padding--medium">{Utils.ipsum('paragraph', 2)}</div>
+      ),
+      notes: ''
+    }, {
+      name: 'Large padding',
+      description: '',
+      staticPath: '',
+      component: (
+        <div className="padding--large">{Utils.ipsum('paragraph', 2)}</div>
+      ),
+      notes: ''
+    }, {
+      name: 'Extra large padding',
+      description: '',
+      staticPath: '',
+      component: (
+        <div className="padding--extra-large">{Utils.ipsum('paragraph', 2)}</div>
+      ),
+      notes: ''
+    }
+  ]
+}];


### PR DESCRIPTION
Adds `paddings` modifier that supports for class inner box-model based spacing:

- padding--small
- padding--medium
- padding--large
- padding--extra-large

- padding--small-top
- padding--small-bottom
- padding--small-left
- padding--small-right

- padding--medium-top
- padding--medium-bottom
- padding--medium-left
- padding--medium-right

- padding--large-top
- padding--large-bottom
- padding--large-left
- padding--large-right

- padding--extra-large-top
- padding--extra-large-bottom
- padding--extra-large-left
- padding--extra-large-right

The goal of this modifier is create a inner box modeling spacing pattern from designs that not only makes spacing consistent, but cuts a lot of CSS from our bundles. #188 