### PR TITLE
Brand Slogan Fix

### DIFF
--- a/src/elements/molecules/Brand/Brand.jsx
+++ b/src/elements/molecules/Brand/Brand.jsx
@@ -48,7 +48,7 @@ export class Brand extends React.Component {
       <Tag className={classStack} {...attrs}>
         <Icon name="brand" className="brand__icon" />
         {
-          variant === 'default' && <span className="brand__label">{slogan}</span>
+          slogan && <span className="brand__label">{slogan}</span>
         }
       </Tag>
     );


### PR DESCRIPTION
This fixes the condition used on Branding to be that of slogan to include or exclude it's supporting span tag. 

#194 