### PR TITLE
Node Version Checker Operator

### DIFF
--- a/build/scaffolding/node.build.js
+++ b/build/scaffolding/node.build.js
@@ -24,7 +24,7 @@ const sync = () => {
 
   console.log('\x1b[33mChecking system node version . . .\x1b[37m');
 
-  if (systemNode !== neededNode) {
+  if (systemNode < neededNode) {
     console.log(`\x1b[31mError: System NodeJS version is \x1b[33m${systemNode}\x1b[31m, while this project requires \x1b[33m${neededNode}\x1b[31m!\nPlease use the recommended version and try again.\x1b[37m`);
     process.exit(1);
     return false;


### PR DESCRIPTION
This changes Unslated's node version checker to be not "must be equal to specific version", but instead "must not be less than specific version". This allows developers to work on recommend version as well as later version.

However its does mean some bugs with Unslated might be a little allusive to solve as it could very well pertain to nodejs changes outside of our purview.

#183 