### PR TITLE
Aria-pressed Update

### DIFF
--- a/src/elements/atoms/Button/Button.example.jsx
+++ b/src/elements/atoms/Button/Button.example.jsx
@@ -59,7 +59,7 @@ export default [{
   }, {
     name: 'Toggle aria-pressed attribute',
     component: (
-      <Button tagName="div" aria-label="Specific link info for screen readers (required)">I have a pressed state.. Try me!</Button>
+      <Button tagName="div" aria-pressed="false" aria-label="Specific link info for screen readers (required)">I have a pressed state.. Try me!</Button>
     )
   }, {
     name: 'Icon button',

--- a/src/elements/atoms/Button/Button.jsx
+++ b/src/elements/atoms/Button/Button.jsx
@@ -19,16 +19,13 @@ export class Button extends React.Component {
     /** If used, button becomes an anchor tag with button styles */
     href: PropTypes.string,
     /** Children nodes being passed through */
-    children: PropTypes.node,
-    /** Defineds the accessibility pressed state for foreign tag usage */
-    'aria-pressed': PropTypes.string
+    children: PropTypes.node
   };
 
   static defaultProps = {
     tagName: 'button',
     variant: 'primary',
-    size: 'inline',
-    'aria-pressed': 'false'
+    size: 'inline'
   };
 
   /** Element level options */

--- a/src/elements/modifiers/Accessibility/Accessibility.container.js
+++ b/src/elements/modifiers/Accessibility/Accessibility.container.js
@@ -60,8 +60,12 @@ export const Accessibility = (el) => {
           if (type === 'click') {
             target.ariaPressed = !(target.ariaPressed === 'true');
           } else if (event.which === 13 || event.which === 32) {
-            event.preventDefault();
-            target.ariaPressed = !(target.ariaPressed === 'true');
+            if (target.tagName !== 'BUTTON') {
+              event.preventDefault();
+              target.ariaPressed = !(target.ariaPressed === 'true');
+            } else {
+              target.ariaPressed = !(target.ariaPressed === 'true');
+            }
           }
         }
       });

--- a/src/elements/modifiers/Accessibility/Accessibility.container.js
+++ b/src/elements/modifiers/Accessibility/Accessibility.container.js
@@ -56,7 +56,7 @@ export const Accessibility = (el) => {
         const { target } = event;
 
         // Logic for aria pressed
-        if (target.ariaPressed && ['click', 'keydown'].indexOf(type) !== -1) {
+        if (target.ariaPressed && ['click', 'keyup'].indexOf(type) !== -1) {
           if (type === 'click') {
             target.ariaPressed = !(target.ariaPressed === 'true');
           } else if (event.which === 13 || event.which === 32) {


### PR DESCRIPTION
- This removes the default `aria-pressed` prop, as it should only be used on buttons with toggle state
- This adds a condition to check for buttons with foreign tags to prevent default keyboard events