### PR TITLE
UCL-54: Modal Enhancments

### DIFF
--- a/src/elements/atoms/Wrapper/Wrapper.css
+++ b/src/elements/atoms/Wrapper/Wrapper.css
@@ -3,15 +3,19 @@
   padding: 2em;
 
   /* sizes */
-  &--narrow {
+  &--small {
     max-width: 640px;
   }
 
-  &--default {
-    max-width: 960px;
+  &--medium {
+    max-width: 896px;
   }
 
-  &--wide {
-    max-width: 1280px;
+  &--large {
+    max-width: 1024px;
+  }
+
+  &--extra-large {
+    max-width: 1152px;
   }
 }

--- a/src/elements/modifiers/Accessibility/Accessibility.css
+++ b/src/elements/modifiers/Accessibility/Accessibility.css
@@ -5,8 +5,17 @@
 
 .accessibility {
 
-  /* Demo variants */
-  &[aria-pressed="true"] {
-    background-color: var(--color-gray-light);
-  }
+  /* Accessibility variants */
+
+}
+
+/* Screen reader friendly hidden class */
+.hidden {
+  height: 0;
+  width: 0;
+  overflow: hidden;
+  position: absolute;
+  left: -999rem;
+  top: -999rem;
+  z-index: var(--zindex--hidden);
 }

--- a/src/elements/molecules/Card/Card.jsx
+++ b/src/elements/molecules/Card/Card.jsx
@@ -15,7 +15,7 @@ export class Card extends React.Component {
     /** Style variants */
     variant: PropTypes.oneOf(['default']),
     /** Children passed through */
-    children: PropTypes.node
+    children: PropTypes.any
   };
 
   static defaultProps = {
@@ -67,7 +67,7 @@ export class Card__header extends React.Component {
     /** Style variants */
     variant: PropTypes.oneOf(['default']),
     /** Children passed through */
-    children: PropTypes.node
+    children: PropTypes.any
   };
 
   static defaultProps = {
@@ -114,7 +114,7 @@ export class Card__body extends React.Component {
     /** Style variants */
     variant: PropTypes.oneOf(['default']),
     /** Children passed through */
-    children: PropTypes.node
+    children: PropTypes.any
   };
 
   static defaultProps = {
@@ -161,7 +161,7 @@ export class Card__footer extends React.Component {
     /** Style variants */
     variant: PropTypes.oneOf(['default']),
     /** Children passed through */
-    children: PropTypes.node
+    children: PropTypes.any
   };
 
   static defaultProps = {

--- a/src/elements/molecules/Modal/Modal.container.js
+++ b/src/elements/molecules/Modal/Modal.container.js
@@ -12,7 +12,7 @@ export const Modal = (el) => {
     if (!modal.classList.contains('hidden')) {
       modal.classList.remove('overflowing');
       modal.classList[
-        (window.innerHeight <= (ui.innerWidth.clientHeight + 96))
+        (window.innerHeight <= (ui.innerWidth.clientHeight + 128))
           ? 'add'
           : 'remove'
       ]('overflowing');
@@ -43,7 +43,7 @@ export const Modal = (el) => {
     modal.removeAttribute('data-href');
     modal.removeAttribute('data-modal-hide');
     modal.classList.add('hidden');
-    window.removeEventListener('resize', handleWindowResize, true);
+    // window.removeEventListener('resize', handleWindowResize, true);
   };
 
   // Get modal by ID
@@ -54,16 +54,16 @@ export const Modal = (el) => {
     // Moves modal out of DOM and into body for developers.
     document.body.appendChild(ui.modal);
 
+    // One global event listener for modals
+    if (window.modals) { return false; }
+    window.modal = true;
+
     // Setup resize listener for modal windows
     window.addEventListener(
       'resize',
       handleWindowResize,
       true
     );
-
-    // One global event listener for modals
-    if (window.modals) { return false; }
-    window.modal = true;
 
     document.body.addEventListener('click', (event) => {
       const { target } = event;
@@ -98,6 +98,11 @@ export const Modal = (el) => {
         close(ui.modal);
       }
     });
+
+    // Hoist methods onto modal's DOM for other components to access
+    el.checkHeight = checkHeight;
+    el.close = close;
+    el.open = open;
 
     return true;
   };

--- a/src/elements/molecules/Modal/Modal.container.js
+++ b/src/elements/molecules/Modal/Modal.container.js
@@ -8,31 +8,33 @@ export const Modal = (el) => {
   };
 
   // checks if window height is smaller than modal height
-  const checkHeight = () => {
-    const elm = document.querySelector('.modal-visible');
-    if (!elm) { return; }
-
-    elm.classList.remove('overflowing');
-    elm.classList[(window.innerHeight <= (ui.innerWidth.clientHeight + 96)) ? 'add' : 'remove']('overflowing');
+  const checkHeight = (modal) => {
+    if (!modal.classList.contains('hidden')) {
+      modal.classList.remove('overflowing');
+      modal.classList[
+        (window.innerHeight <= (ui.innerWidth.clientHeight + 96))
+          ? 'add'
+          : 'remove'
+      ]('overflowing');
+    }
   };
 
   // window resize event
-  const handleWindowResize = () => checkHeight();
+  const handleWindowResize = () => checkHeight(ui.modal);
 
   // Open modal
   const open = (modal, trigger) => {
     if (!modal || !modal.classList) { return; }
 
-    if (trigger.hasAttribute('href')) {
+    if (trigger.href) {
       modal.dataset.href = trigger.href;
     }
 
-    modal.classList.add('modal-visible');
+    modal.classList.remove('hidden');
     modal.removeAttribute('data-modal-hide');
+    modal.focus();
 
-    setTimeout(() => {
-      checkHeight();
-    });
+    checkHeight(ui.modal);
   };
 
   // Close modal
@@ -40,7 +42,7 @@ export const Modal = (el) => {
     if (!modal || !modal.classList) { return; }
     modal.removeAttribute('data-href');
     modal.removeAttribute('data-modal-hide');
-    modal.classList.remove('modal-visible');
+    modal.classList.add('hidden');
     window.removeEventListener('resize', handleWindowResize, true);
   };
 
@@ -49,28 +51,55 @@ export const Modal = (el) => {
 
   // Modals's main init method
   const init = () => {
+    // Moves modal out of DOM and into body for developers.
     document.body.appendChild(ui.modal);
-    window.addEventListener('resize', handleWindowResize, true);
 
+    // Setup resize listener for modal windows
+    window.addEventListener(
+      'resize',
+      handleWindowResize,
+      true
+    );
+
+    // One global event listener for modals
     if (window.modals) { return false; }
-    document.body.addEventListener('click', (e) => {
-      const { dataset } = e.target;
-      const { classList } = e.target;
-
-      if (dataset) {
-        if (dataset.modal && !classList.contains('modal')) {
-          open(getRefModal(dataset.modal), e.target);
-          e.preventDefault();
-        }
-
-        if (dataset.modalClose || classList.contains('modal')) {
-          close(ui.modal);
-        }
-      }
-    });
     window.modal = true;
 
-    return false;
+    document.body.addEventListener('click', (event) => {
+      const { target } = event;
+      const { dataset } = target;
+      const { classList } = target;
+
+      if (!dataset) { return; }
+
+      if (dataset.modal && !classList.contains('modal')) {
+        open(getRefModal(dataset.modal), target);
+        event.preventDefault();
+      }
+
+      if (classList.contains('modal-close')) {
+        close(ui.modal);
+      }
+
+      if (
+        classList.contains('modal')
+        && classList.contains('modal--overlay-close-true')
+      ) {
+        close(ui.modal);
+      }
+    });
+
+    document.body.addEventListener('keyup', (event) => {
+      if (
+        !ui.modal.classList.contains('hidden')
+        && !ui.modal.classList.contains('modal--escape-close-false')
+        && event.which === 27
+      ) {
+        close(ui.modal);
+      }
+    });
+
+    return true;
   };
 
   // Self init

--- a/src/elements/molecules/Modal/Modal.css
+++ b/src/elements/molecules/Modal/Modal.css
@@ -79,10 +79,7 @@
     width: 100%;
 
     &--width {
-      display: flex;
-      flex-direction: column;
       height: 100%;
-      justify-content: center;
       margin: auto;
       position: relative;
       transform: scale(0);
@@ -104,27 +101,6 @@
   &--large .modal-inner      { max-width: var(--size-large);      }
 
   &--extraLarge .modal-inner { max-width: var(--size-extraLarge); }
-
-  /* padding variants */
-  &--padding-none {
-    .modal-inner--width,
-    .modal-inner--height { padding: 0; }
-  }
-
-  &--padding-small {
-    .modal-inner--width,
-    .modal-inner--height { padding: var(--padding-small); }
-  }
-
-  &--padding-medium {
-    .modal-inner--width,
-    .modal-inner--height { padding: var(--padding-medium); }
-  }
-
-  &--padding-large {
-    .modal-inner--width,
-    .modal-inner--height { padding: var(--padding-large); }
-  }
 
   /* style variants */
   &--default .modal-inner--width {

--- a/src/elements/molecules/Modal/Modal.css
+++ b/src/elements/molecules/Modal/Modal.css
@@ -1,20 +1,18 @@
-:root {
-  --size-small: 480px;
-  --size-medium: 768px;
-  --size-large: 1024px;
-  --size-extra-large: 1200px;
-}
-
 .modal {
   -webkit-overflow-scrolling: touch;
   bottom: 0;
   left: 0;
+  padding: rem(75px) rem(48px) rem(24px) rem(48px);
   position: fixed;
   right: 0;
   text-align: center;
   top: 0;
   transition: opacity 0.2s, z-index 0s 0.2s;
   white-space: nowrap;
+
+  @media (--large) {
+    padding: rem(96px) rem(75px) rem(75px);
+  }
 
   /* Aspect ratio helper */
   &:before {
@@ -26,21 +24,41 @@
     width: 0;
   }
 
-  & > * {
-    display: inline-block;
-    text-align: left;
-    vertical-align: middle;
-    white-space: normal;
+  .card__header {
+    bottom: 100%;
+    position: absolute;
+    width: 100%;
+  }
+
+  .card__body {
+    min-height: 40px;
   }
 
   &.hidden {
+    left: -999rem;
+    top: -999rem;
+
     .modal-inner--width {
       transform: scale(0);
     }
   }
 
+  &--title-hidden {
+    padding: rem(48px) rem(48px) rem(24px) rem(48px);
+
+    .modal-close {
+      position: absolute;
+      right: 5px;
+      top: -35px;
+    }
+  }
+
   /* Inner container */
   &-inner {
+    display: inline-block;
+    text-align: left;
+    vertical-align: middle;
+    white-space: normal;
     width: 100%;
 
     &--width {
@@ -70,31 +88,18 @@
     & .modal-inner--height,
     & .card__body {
       height: 100%;
+      min-height: 100px;
     }
 
     & .card__body {
-      .scrollblock {
-        overflow-x: hidden;
-        overflow-y: scroll;
-      }
+      overflow: hidden;
     }
-  }
 
-  /* size variants */
-  &--small .modal-inner {
-    max-width: var(--size-small);
-  }
-
-  &--medium .modal-inner {
-    max-width: var(--size-medium);
-  }
-
-  &--large .modal-inner {
-    max-width: var(--size-large);
-  }
-
-  &--extra-large .modal-inner {
-    max-width: var(--size-extra-large);
+    .scrollblock {
+      min-height: 40px;
+      overflow-x: hidden;
+      overflow-y: scroll;
+    }
   }
 
   /* Style variants */
@@ -103,6 +108,7 @@
 
     .modal-content {
       background: var(--color-white);
+      position: relative;
     }
   }
 
@@ -114,9 +120,6 @@
     height: 25px;
     line-height: 25px;
     padding: 0;
-    position: absolute;
-    right: 5px;
-    top: -35px;
     z-index: calc(var(--zindex--content) + 2);
 
     &:before {
@@ -132,11 +135,5 @@
     &:--haf {
       background-color: transparent;
     }
-  }
-
-  .card &-close {
-    position: relative;
-    right: 0;
-    top: 0;
   }
 }

--- a/src/elements/molecules/Modal/Modal.css
+++ b/src/elements/molecules/Modal/Modal.css
@@ -2,28 +2,21 @@
   --size-small: 480px;
   --size-medium: 768px;
   --size-large: 1024px;
-  --size-extraLarge: 1200px;
-
-  --padding-small: rem(16px);
-  --padding-medium: rem(32px);
-  --padding-large: rem(48px);
+  --size-extra-large: 1200px;
 }
 
 .modal {
-  background: rgba(0, 0, 0, 0.25);
+  -webkit-overflow-scrolling: touch;
   bottom: 0;
-  display: none;
   left: 0;
-  opacity: 0;
   position: fixed;
   right: 0;
   text-align: center;
   top: 0;
   transition: opacity 0.2s, z-index 0s 0.2s;
   white-space: nowrap;
-  z-index: -1;
-  -webkit-overflow-scrolling: touch;
 
+  /* Aspect ratio helper */
   &:before {
     content: '';
     display: inline-block;
@@ -33,24 +26,6 @@
     width: 0;
   }
 
-  /* for multiple modals */
-  &[data-modal-hide] {
-    &.modal-visible {
-      display: none;
-    }
-  }
-
-  &.overflowing {
-    & .modal-inner {
-      height: 100%;
-
-      &--height {
-        overflow-x: hidden;
-        overflow-y: scroll;
-      }
-    }
-  }
-
   & > * {
     display: inline-block;
     text-align: left;
@@ -58,34 +33,23 @@
     white-space: normal;
   }
 
-  & .button { margin-top: rem(16px); }
-
-  &-visible {
-    display: block;
-    opacity: 1;
-    transition: opacity 0.2s;
-    z-index: 99;
-
-    & .modal-inner--width {
-      opacity: 1;
-      transform: scale(1);
-      transition: opacity 0.2s, transform 0.2s;
-      z-index: 100;
+  &.hidden {
+    .modal-inner--width {
+      transform: scale(0);
     }
   }
 
+  /* Inner container */
   &-inner {
-    padding: rem(64px) rem(16px) rem(32px);
     width: 100%;
 
     &--width {
       height: 100%;
       margin: auto;
       position: relative;
-      transform: scale(0);
-      transition: opacity 0.2s, transform 0.2s, z-index 0s 0.2s;
+      transform: scale(1);
+      transition: all 0.15s;
       width: 100%;
-      z-index: -1;
 
       @media (--large) {
         margin: 0;
@@ -93,29 +57,86 @@
     }
   }
 
-  /* size variants */
-  &--small .modal-inner      { max-width: var(--size-small);      }
+  /* Supporting style for element options */
+  &--overlay-false { background: transparent !important; }
 
-  &--medium .modal-inner     { max-width: var(--size-medium);     }
+  /* For small viewports */
+  &.overflowing {
+    & .card,
+    & .card__body,
+    & .scrollblock,
+    & .modal-inner,
+    & .modal-inner--width,
+    & .modal-inner--height,
+    & .card__body {
+      height: 100%;
+    }
 
-  &--large .modal-inner      { max-width: var(--size-large);      }
-
-  &--extraLarge .modal-inner { max-width: var(--size-extraLarge); }
-
-  /* style variants */
-  &--default .modal-inner--width {
-    background: var(--color-white);
-    border-radius: 4px;
+    & .card__body {
+      .scrollblock {
+        overflow-x: hidden;
+        overflow-y: scroll;
+      }
+    }
   }
 
-  .icon--close {
+  /* size variants */
+  &--small .modal-inner {
+    max-width: var(--size-small);
+  }
+
+  &--medium .modal-inner {
+    max-width: var(--size-medium);
+  }
+
+  &--large .modal-inner {
+    max-width: var(--size-large);
+  }
+
+  &--extra-large .modal-inner {
+    max-width: var(--size-extra-large);
+  }
+
+  /* Style variants */
+  &--default {
+    background: rgba(0, 0, 0, 0.25);
+
+    .modal-content {
+      background: var(--color-white);
+    }
+  }
+
+  /* Close variants */
+  &-close {
+    background-color: transparent;
+    border: none;
     cursor: pointer;
     height: 25px;
     line-height: 25px;
+    padding: 0;
     position: absolute;
     right: 5px;
     top: -35px;
-    width: 25px;
-    z-index: 2;
+    z-index: calc(var(--zindex--content) + 2);
+
+    &:before {
+      content: '';
+      height: 100%;
+      left: 0;
+      position: absolute;
+      top: 0;
+      width: 100%;
+      z-index: var(--zindex--content);
+    }
+
+    &:--haf {
+      background-color: transparent;
+    }
+  }
+
+  .card &-close {
+    position: relative;
+    right: 0;
+    top: 0;
   }
 }

--- a/src/elements/molecules/Modal/Modal.example.jsx
+++ b/src/elements/molecules/Modal/Modal.example.jsx
@@ -21,156 +21,129 @@
     ```
 */
 
+import Icon from '@atoms/Icon/Icon';
 import Button from '@atoms/Button/Button';
-import { List, List__item } from '@atoms/List/List';
 import Modal from './Modal';
 
 export default [{
   examples: [
     {
-      name: 'Small Layout / Small Padding',
-      description: 'A small size modal example (with small padding)',
+      name: 'Modal Sizes',
+      description: '',
       component: (
         <React.Fragment>
-          <Button data-modal="my-modal-id-02">Click to open</Button>
-          <Modal data-modal="my-modal-id-02" size="small">
-            <List tagName="ul" className="list--small list--ordered list--color-light">
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-            </List>
+          <Button data-modal="my-modal-id-01">Small Layout (click me)</Button>
+          <Modal data-modal="my-modal-id-01" size="small" title="Small modal layout example">
+            <p>{Utils.ipsum('paragraph', 1)}</p>
+          </Modal>
+
+          <Button data-modal="my-modal-id-02">Medium Layout (click me)</Button>
+          <Modal data-modal="my-modal-id-02" size="medium" title="Medium modal layout example">
+            <p>{Utils.ipsum('paragraph', 2)}</p>
+          </Modal>
+
+          <Button data-modal="my-modal-id-03">Large Layout (click me)</Button>
+          <Modal data-modal="my-modal-id-03" size="large" title="Large modal layout example">
+            <p>{Utils.ipsum('paragraph', 3)}</p>
+          </Modal>
+
+          <Button data-modal="my-modal-id-04">Extra Layout large (click me)</Button>
+          <Modal data-modal="my-modal-id-04" size="extra-large" padding="medium" title="Extra large layout example">
+            <p>{Utils.ipsum('paragraph', 4)}</p>
           </Modal>
         </React.Fragment>
       )
     }, {
-      name: 'Medium Layout / Small Padding',
-      description: 'A medium size modal example (with medium padding)',
+      name: 'Modal Paddings',
+      description: '',
       component: (
         <React.Fragment>
-          <Button data-modal="my-modal-id-03">Click to open</Button>
-          <Modal data-modal="my-modal-id-03" size="medium">
-            <List tagName="ul" className="list--small list--ordered list--color-light">
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-            </List>
+          <Button data-modal="my-modal-id-05">Small Padding (click me)</Button>
+          <Modal data-modal="my-modal-id-05" size="extra-large" padding="small" title="Small padding example">
+            {Utils.ipsum('paragraph', 4)}
+          </Modal>
+
+          <Button data-modal="my-modal-id-06">Medium Padding (click me)</Button>
+          <Modal data-modal="my-modal-id-06" size="extra-large" padding="medium" title="Medium padding example">
+            {Utils.ipsum('paragraph', 3)}
+          </Modal>
+
+          <Button data-modal="my-modal-id-07">Large Padding (click me)</Button>
+          <Modal data-modal="my-modal-id-07" size="extra-large" padding="large" title="Large padding example">
+            {Utils.ipsum('paragraph', 2)}
           </Modal>
         </React.Fragment>
       )
     }, {
-      name: 'Large Layout / Small Padding',
-      description: 'A default modal example that has a default size of large',
+      name: 'Modal custom close',
+      description: '',
       component: (
         <React.Fragment>
-          <Button data-modal="my-modal-id-01">Click to open</Button>
-          <Modal data-modal="my-modal-id-01" size="large">
-            <List tagName="ul" className="list--small list--ordered list--color-light">
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-            </List>
+          <Button data-modal="my-modal-id-08">Textual Close (click me)</Button>
+          <Modal data-modal="my-modal-id-08" close="Close text" title="Textual close example">
+            {Utils.ipsum('paragraph', 1)}
+          </Modal>
+
+          <Button data-modal="my-modal-id-09">Icon Close (click me)</Button>
+          <Modal data-modal="my-modal-id-09" close={<Icon name="down" />} title="Icon close example">
+            {Utils.ipsum('paragraph', 1)}
+          </Modal>
+
+          <Button data-modal="my-modal-id-10">Elemental Close (click me)</Button>
+          <Modal
+            data-modal="my-modal-id-10"
+            close={<span style={{ backgroundColor: '#999', color: '#fff', padding: '0.25rem' }}>Close element</span>}
+            title="Elemental close example"
+          >
+            {Utils.ipsum('paragraph', 1)}
           </Modal>
         </React.Fragment>
       )
     }, {
-      name: 'Extra Large Layout / Medium Padding',
-      description: 'A large size modal example (with large padding)',
+      name: 'Close Disabling',
+      description: '',
       component: (
         <React.Fragment>
-          <Button data-modal="my-modal-id-04">Click to open</Button>
-          <Modal data-modal="my-modal-id-04" size="extraLarge" padding="medium">
-            <List tagName="ul" className="list--small list--ordered list--color-light">
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-            </List>
+          <Button data-modal="my-modal-id-11">Disable Esc Close (click me)</Button>
+          <Modal data-modal="my-modal-id-11" hasEscapeClose={false} title="Disabled Esc example">
+            {Utils.ipsum('paragraph', 1)}
+          </Modal>
+
+          <Button data-modal="my-modal-id-12">Disable Esc & Overlay Close (click me)</Button>
+          <Modal data-modal="my-modal-id-12" hasEscapeClose={false} hasOverlayClose={false} title="Disabled Esc & overlay example">
+            {Utils.ipsum('paragraph', 1)}
+          </Modal>
+
+          <Button data-modal="my-modal-id-13">Disable Overlay Close & Close Button (click me)</Button>
+          <Modal data-modal="my-modal-id-13" hasOverlayClose={false} close={false} title="Disabled overlay & close example (hint: press esc)">
+            {Utils.ipsum('paragraph', 1)}
+          </Modal>
+        </React.Fragment>
+      )
+    }, {
+      name: 'Disabling Overlay',
+      description: '',
+      component: (
+        <React.Fragment>
+          <Button data-modal="my-modal-id-14">Disable Overlay (click me)</Button>
+          <Modal data-modal="my-modal-id-14" hasOverlay={false} title="Disabled overlay example">
+            {Utils.ipsum('paragraph', 1)}
+          </Modal>
+
+          <Button data-modal="my-modal-id-15">Disable Overlay & Overlay Close (click me)</Button>
+          <Modal data-modal="my-modal-id-15" hasOverlayClose={false} hasOverlay={false} title="Disabled overlay & overlay close">
+            {Utils.ipsum('paragraph', 1)}
+          </Modal>
+        </React.Fragment>
+      )
+    }, {
+      name: 'Hide Title',
+      description: '',
+      component: (
+        <React.Fragment>
+          <Button data-modal="my-modal-id-16">Disable Overlay (click me)</Button>
+          <Modal data-modal="my-modal-id-16" size="small" hideTitle={true} title="Disabled overlay example">
+            {Utils.ipsum('paragraph', 3)}
           </Modal>
         </React.Fragment>
       )

--- a/src/elements/molecules/Modal/Modal.example.jsx
+++ b/src/elements/molecules/Modal/Modal.example.jsx
@@ -80,18 +80,19 @@ export default [{
       component: (
         <React.Fragment>
           <Button data-modal="my-modal-id-08">Textual Close (click me)</Button>
-          <Modal data-modal="my-modal-id-08" close="Close text" title="Textual close example">
+          <Modal data-modal="my-modal-id-08" size="small" close="Close text" title="Textual close example">
             {Utils.ipsum('paragraph', 1)}
           </Modal>
 
           <Button data-modal="my-modal-id-09">Icon Close (click me)</Button>
-          <Modal data-modal="my-modal-id-09" close={<Icon name="down" />} title="Icon close example">
+          <Modal data-modal="my-modal-id-09" size="small" close={<Icon name="down" />} title="Icon close example">
             {Utils.ipsum('paragraph', 1)}
           </Modal>
 
           <Button data-modal="my-modal-id-10">Elemental Close (click me)</Button>
           <Modal
             data-modal="my-modal-id-10"
+            size="small"
             close={<span style={{ backgroundColor: '#999', color: '#fff', padding: '0.25rem' }}>Close element</span>}
             title="Elemental close example"
           >
@@ -105,17 +106,17 @@ export default [{
       component: (
         <React.Fragment>
           <Button data-modal="my-modal-id-11">Disable Esc Close (click me)</Button>
-          <Modal data-modal="my-modal-id-11" hasEscapeClose={false} title="Disabled Esc example">
+          <Modal data-modal="my-modal-id-11" size="small" hasEscapeClose={false} title="Disabled Esc example">
             {Utils.ipsum('paragraph', 1)}
           </Modal>
 
           <Button data-modal="my-modal-id-12">Disable Esc & Overlay Close (click me)</Button>
-          <Modal data-modal="my-modal-id-12" hasEscapeClose={false} hasOverlayClose={false} title="Disabled Esc & overlay example">
+          <Modal data-modal="my-modal-id-12" size="small" hasEscapeClose={false} hasOverlayClose={false} title="Disabled Esc & overlay example">
             {Utils.ipsum('paragraph', 1)}
           </Modal>
 
           <Button data-modal="my-modal-id-13">Disable Overlay Close & Close Button (click me)</Button>
-          <Modal data-modal="my-modal-id-13" hasOverlayClose={false} close={false} title="Disabled overlay & close example (hint: press esc)">
+          <Modal data-modal="my-modal-id-13" size="small" hasOverlayClose={false} close={false} title="Disabled overlay & close example (hint: press esc)">
             {Utils.ipsum('paragraph', 1)}
           </Modal>
         </React.Fragment>
@@ -126,12 +127,12 @@ export default [{
       component: (
         <React.Fragment>
           <Button data-modal="my-modal-id-14">Disable Overlay (click me)</Button>
-          <Modal data-modal="my-modal-id-14" hasOverlay={false} title="Disabled overlay example">
+          <Modal data-modal="my-modal-id-14" size="small" hasOverlay={false} title="Disabled overlay example">
             {Utils.ipsum('paragraph', 1)}
           </Modal>
 
           <Button data-modal="my-modal-id-15">Disable Overlay & Overlay Close (click me)</Button>
-          <Modal data-modal="my-modal-id-15" hasOverlayClose={false} hasOverlay={false} title="Disabled overlay & overlay close">
+          <Modal data-modal="my-modal-id-15" size="small" hasOverlayClose={false} hasOverlay={false} title="Disabled overlay & overlay close">
             {Utils.ipsum('paragraph', 1)}
           </Modal>
         </React.Fragment>
@@ -141,7 +142,7 @@ export default [{
       description: '',
       component: (
         <React.Fragment>
-          <Button data-modal="my-modal-id-16">Disable Overlay (click me)</Button>
+          <Button data-modal="my-modal-id-16">Simple Modal without title</Button>
           <Modal data-modal="my-modal-id-16" size="small" hideTitle={true} title="Disabled overlay example">
             {Utils.ipsum('paragraph', 3)}
           </Modal>

--- a/src/elements/molecules/Modal/Modal.example.jsx
+++ b/src/elements/molecules/Modal/Modal.example.jsx
@@ -28,51 +28,12 @@ import Modal from './Modal';
 export default [{
   examples: [
     {
-      name: 'Default (large size, medium padding)',
-      description: 'A default modal example that has a default size of large',
-      component: (
-        <React.Fragment>
-          <Button data-modal="my-modal-id-01">Click to open</Button>
-          <Modal data-modal="my-modal-id-01">
-            <List tagName="ul" className="list--small list--ordered list--color-light">
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-              <List__item>
-                <p>{Utils.ipsum('sentence', 1)}</p>
-              </List__item>
-            </List>
-          </Modal>
-        </React.Fragment>
-      )
-    }, {
-      name: 'Small',
+      name: 'Small Layout / Small Padding',
       description: 'A small size modal example (with small padding)',
       component: (
         <React.Fragment>
           <Button data-modal="my-modal-id-02">Click to open</Button>
-          <Modal data-modal="my-modal-id-02" size="small" padding="small">
+          <Modal data-modal="my-modal-id-02" size="small">
             <List tagName="ul" className="list--small list--ordered list--color-light">
               <List__item>
                 <p>{Utils.ipsum('sentence', 1)}</p>
@@ -97,12 +58,12 @@ export default [{
         </React.Fragment>
       )
     }, {
-      name: 'Medium',
+      name: 'Medium Layout / Small Padding',
       description: 'A medium size modal example (with medium padding)',
       component: (
         <React.Fragment>
           <Button data-modal="my-modal-id-03">Click to open</Button>
-          <Modal data-modal="my-modal-id-03" size="medium" padding="medium">
+          <Modal data-modal="my-modal-id-03" size="medium">
             <List tagName="ul" className="list--small list--ordered list--color-light">
               <List__item>
                 <p>{Utils.ipsum('sentence', 1)}</p>
@@ -136,12 +97,51 @@ export default [{
         </React.Fragment>
       )
     }, {
-      name: 'Extra large',
+      name: 'Large Layout / Small Padding',
+      description: 'A default modal example that has a default size of large',
+      component: (
+        <React.Fragment>
+          <Button data-modal="my-modal-id-01">Click to open</Button>
+          <Modal data-modal="my-modal-id-01" size="large">
+            <List tagName="ul" className="list--small list--ordered list--color-light">
+              <List__item>
+                <p>{Utils.ipsum('sentence', 1)}</p>
+              </List__item>
+              <List__item>
+                <p>{Utils.ipsum('sentence', 1)}</p>
+              </List__item>
+              <List__item>
+                <p>{Utils.ipsum('sentence', 1)}</p>
+              </List__item>
+              <List__item>
+                <p>{Utils.ipsum('sentence', 1)}</p>
+              </List__item>
+              <List__item>
+                <p>{Utils.ipsum('sentence', 1)}</p>
+              </List__item>
+              <List__item>
+                <p>{Utils.ipsum('sentence', 1)}</p>
+              </List__item>
+              <List__item>
+                <p>{Utils.ipsum('sentence', 1)}</p>
+              </List__item>
+              <List__item>
+                <p>{Utils.ipsum('sentence', 1)}</p>
+              </List__item>
+              <List__item>
+                <p>{Utils.ipsum('sentence', 1)}</p>
+              </List__item>
+            </List>
+          </Modal>
+        </React.Fragment>
+      )
+    }, {
+      name: 'Extra Large Layout / Medium Padding',
       description: 'A large size modal example (with large padding)',
       component: (
         <React.Fragment>
           <Button data-modal="my-modal-id-04">Click to open</Button>
-          <Modal data-modal="my-modal-id-04" size="extraLarge" padding="large">
+          <Modal data-modal="my-modal-id-04" size="extraLarge" padding="medium">
             <List tagName="ul" className="list--small list--ordered list--color-light">
               <List__item>
                 <p>{Utils.ipsum('sentence', 1)}</p>

--- a/src/elements/molecules/Modal/Modal.jsx
+++ b/src/elements/molecules/Modal/Modal.jsx
@@ -29,7 +29,7 @@ export class Modal extends React.Component {
     tagName: 'div',
     variant: 'default',
     size: 'large',
-    padding: 'medium'
+    padding: 'small'
   };
 
   /** Element level options */
@@ -52,8 +52,20 @@ export class Modal extends React.Component {
       'modal',
       `modal--${variant}`,
       `modal--${size}`,
-      `modal--padding-${padding}`,
       className
+    ]);
+
+    const widthStack = Utils.createClassStack([
+      'modal-inner--width',
+      'flex',
+      'flex--column',
+      'flex--justify-content-center',
+      `padding--${padding}`
+    ]);
+
+    const heightStack = Utils.createClassStack([
+      'modal-inner--height',
+      `padding--${padding}`
     ]);
 
     return (
@@ -62,9 +74,9 @@ export class Modal extends React.Component {
         {...attrs}
       >
         <div className="modal-inner">
-          <div className="modal-inner--width">
+          <div className={widthStack}>
             <Icon name="close" data-modal-close />
-            <div className="modal-inner--height">
+            <div className={heightStack}>
               <div className="modal-content">
                 {children}
               </div>

--- a/src/elements/molecules/Modal/Modal.jsx
+++ b/src/elements/molecules/Modal/Modal.jsx
@@ -84,9 +84,7 @@ export class Modal extends React.Component {
     const classStack = Utils.createClassStack([
       'modal',
       'hidden',
-      'padding--small-top',
-      'padding--small-bottom',
-      `modal--${size}`,
+      (hideTitle) && 'modal--title-hidden',
       `modal--${variant}`,
       `modal--overlay-${hasOverlay}`,
       `modal--overlay-close-${hasOverlayClose}`,
@@ -127,7 +125,7 @@ export class Modal extends React.Component {
         aria-describedby={`${attrs['data-modal']}Desc`}
         {...attrs}
       >
-        <div className="modal-inner">
+        <div className={`modal-inner wrapper--${size}`}>
           <div className={widthStack}>
             {
               (close && hideTitle)

--- a/src/elements/molecules/Modal/Modal.jsx
+++ b/src/elements/molecules/Modal/Modal.jsx
@@ -1,4 +1,10 @@
 import Icon from '@atoms/Icon/Icon';
+import Button from '@atoms/Button/Button';
+import {
+  Card,
+  Card__header,
+  Card__body
+} from '@molecules/Card/Card';
 
 /**
   A modal is a dialog box/popup window that is displayed on top of the current page.<br/>
@@ -19,17 +25,37 @@ export class Modal extends React.Component {
     variant: PropTypes.oneOf(['default']),
     /** Children passed through */
     children: PropTypes.node,
+    /** Defines the close button text, icon or even element */
+    close: PropTypes.any,
+    /** Defines if modal can be closed with escape key or not */
+    hasEscapeClose: PropTypes.bool,
+    /** Defines if modal can be closed by clicking or touching modal overlay */
+    hasOverlayClose: PropTypes.bool,
+    /** Defines if modal has an overlay background (true by default) */
+    hasOverlay: PropTypes.bool,
     /** Size defines the max width of the modal container */
-    size: PropTypes.oneOf(['small', 'medium', 'large', 'extraLarge']),
+    size: PropTypes.oneOf(['small', 'medium', 'large', 'extra-large']),
     /** Padding defind the inner padding for modals */
-    padding: PropTypes.oneOf(['none', 'small', 'medium', 'large'])
+    padding: PropTypes.oneOf(['none', 'small', 'medium', 'large']),
+    /** Defines the modal's dialog type for screen readers */
+    role: PropTypes.oneOf(['dialog', 'alertdialog']),
+    /** Defines a title for the modal */
+    title: PropTypes.string.isRequired,
+    /** Defines if you wish to visually hide modal title */
+    hideTitle: PropTypes.bool
   };
 
   static defaultProps = {
     tagName: 'div',
     variant: 'default',
     size: 'large',
-    padding: 'small'
+    padding: 'small',
+    close: <Icon name="close" data-modal-close />,
+    hasEscapeClose: true,
+    hasOverlayClose: true,
+    hasOverlay: true,
+    hideTitle: false,
+    role: 'dialog'
   };
 
   /** Element level options */
@@ -39,47 +65,95 @@ export class Modal extends React.Component {
 
   render = () => {
     const {
-      tagName: Tag,
-      className,
+      role,
+      size,
+      title,
+      close,
+      padding,
       variant,
       children,
-      size,
-      padding,
+      className,
+      hideTitle,
+      hasOverlay,
+      tagName: Tag,
+      hasEscapeClose,
+      hasOverlayClose,
       ...attrs
     } = this.props;
 
     const classStack = Utils.createClassStack([
       'modal',
-      `modal--${variant}`,
+      'hidden',
+      'padding--small-top',
+      'padding--small-bottom',
       `modal--${size}`,
+      `modal--${variant}`,
+      `modal--overlay-${hasOverlay}`,
+      `modal--overlay-close-${hasOverlayClose}`,
+      `modal--escape-close-${hasEscapeClose}`,
       className
     ]);
 
     const widthStack = Utils.createClassStack([
-      'modal-inner--width',
       'flex',
       'flex--column',
       'flex--justify-content-center',
-      `padding--${padding}`
+      'modal-inner--width'
     ]);
 
     const heightStack = Utils.createClassStack([
-      'modal-inner--height',
-      `padding--${padding}`
+      'modal-inner--height'
+    ]);
+
+    const titleStack = Utils.createClassStack([
+      'flex',
+      'flex--justify-content-between',
+      'flex--align-items-center',
+      (hideTitle) && 'hidden'
+    ]);
+
+    const closeStack = Utils.createClassStack([
+      'flex',
+      'flex--column',
+      'flex--justify-content-center',
+      'modal-close'
     ]);
 
     return (
       <Tag
         className={classStack}
+        role={role}
+        aria-labelledby={`${attrs['data-modal']}Title`}
+        aria-describedby={`${attrs['data-modal']}Desc`}
         {...attrs}
       >
         <div className="modal-inner">
           <div className={widthStack}>
-            <Icon name="close" data-modal-close />
+            {
+              (close && hideTitle)
+                ? <Button className={closeStack} aria-label="Close dialog">{close}</Button>
+                : ''
+            }
             <div className={heightStack}>
-              <div className="modal-content">
-                {children}
-              </div>
+              <Card className="modal-content">
+                <Card__header
+                  className={titleStack}
+                  id={`${attrs['data-modal']}Title`}
+                  aria-hidden="false"
+                >
+                  {title}
+                  {
+                    (close && !hideTitle)
+                      ? <Button className={closeStack} aria-label="Close dialog">{close}</Button>
+                      : ''
+                  }
+                </Card__header>
+                <Card__body>
+                  <div className={`scrollblock padding--${padding}`} id={`${attrs['data-modal']}Desc`}>
+                    {children}
+                  </div>
+                </Card__body>
+              </Card>
             </div>
           </div>
         </div>

--- a/src/elements/molecules/Modal/Modal.jsx
+++ b/src/elements/molecules/Modal/Modal.jsx
@@ -121,6 +121,7 @@ export class Modal extends React.Component {
       <Tag
         className={classStack}
         role={role}
+        aria-modal="true"
         aria-labelledby={`${attrs['data-modal']}Title`}
         aria-describedby={`${attrs['data-modal']}Desc`}
         {...attrs}


### PR DESCRIPTION
- Moves default markup of modals to that being of a card with a card__header and card__body.
- Adds new aria-labelledby attribute which points to required title dom for screen readers using value/id matching
- Adds new aria-describedby attribute which points to required body dom for screen readers using value/id matching
- Adds new aria-modal attribute which flags this dom as being a modal for screen readers.
- Adds new title prop and marks it required
- Adds new hasEscapeClose boolean prop to disable escape key modal closing
- Adds new hasOverlayClose boolean prop to disable overlay (modal background) clicking / touching modal closing
- Adds new hasOverlay boolean prop to disable overlay (modal background) visually
- Adds new hasTitle boolean prop to visually remove title from modal making it appear less like a dialog
- Adds new role prop to better define how the modal is intended to be used for accessibility (dialog, alertdialog)
- Examples have been updated to better show off size, padding, close disabling and overlay / title removing.
- Updates modal.jsx to use padding modifier classing instead of adding duplicate CSS to modal.css
- Updates modal.jsx to use wrapper atom's size classing instead of adding duplicate CSS to modal.css
- Wrapper atom sizes have been expanded upon to now be small, medium, large and extra-large (our common size pattern) and now reflects our breakpoint variable sizes accurately.

**Note:** title prop is marked required cause accessibility attributes added to modal require a title of some kind to best describe the intent of the modal to screen readers. When disabling title by using the hasTitle={false} prop, we are only visually removing the title, but all requirements still remain for accessibility purposes.