### PR TITLE
UCL-11: Alert updates

### DIFF
--- a/build/configs/css/css.config.plugins.js
+++ b/build/configs/css/css.config.plugins.js
@@ -36,7 +36,7 @@ const colors = postcss.plugin('postcss-color', (options) => {
     let G = (intParse(color[1]) === 0) ? 1 : color[1];
     let B = (intParse(color[2]) === 0) ? 1 : color[2];
     let A = (intParse(color[3]) === 0) ? 1 : color[3];
-    let t = (percent / 100);
+    let t = (percent / 100) * 256; // percent of a range of 256 colors across a million possible shades
 
     return [
       'rgb',
@@ -59,7 +59,7 @@ const colors = postcss.plugin('postcss-color', (options) => {
           const arguments = colors[index].replace(/^color\((.*?)\)$/, '$1').split(',');
           const color = (arguments[0].length < 7) ? (arguments[0] + arguments[0].replace('#', '')) : arguments[0];
 
-          const brightness = parseFloat(arguments[1]);
+          const brightness = (parseFloat(arguments[1]) > 256) ? 256 : parseFloat(arguments[1]);
 
           decl.value = decl.value.replace(colors[index], RGB_Linear_Shade(HexToRGB(color), brightness));
         });

--- a/build/configs/js/js.config.plugins.js
+++ b/build/configs/js/js.config.plugins.js
@@ -294,7 +294,7 @@ const ESDocs = declare((api, opts) => {
           if (ast.node.property.name === 'keys') {
             Object.keys(ast.container.arguments).map((i) => {
               if (!ast.container.arguments[i].property) {
-                console.log();
+                // console.log();
               }
             });
             process.esDocs[elementName].loops.push({

--- a/build/guide/src/elements/molecules/Stylist/Stylist.css
+++ b/build/guide/src/elements/molecules/Stylist/Stylist.css
@@ -3,7 +3,7 @@
   &__stylist {
     background-color: var(--color-white);
     border: 1px #eee solid;
-    box-shadow: 2px 4px 10px 0px color(var(--color-black), 75%);
+    box-shadow: 2px 4px 10px 0px color(var(--color-black), 0.75);
     max-width: 320px;
     position: fixed;
     right: 2rem;

--- a/src/elements/atoms/Button/Button.css
+++ b/src/elements/atoms/Button/Button.css
@@ -56,8 +56,6 @@
   &--icon {
     background-color: transparent;
     border: none;
-    display: flex !important;
-    fill: var(--color-red);
     font-size: rem(16px);
     padding: 2px;
 

--- a/src/elements/atoms/Button/Button.jsx
+++ b/src/elements/atoms/Button/Button.jsx
@@ -49,6 +49,7 @@ export class Button extends React.Component {
     let classStack = Utils.createClassStack([
       'button',
       `button--${variant}`,
+      (variant === 'icon') && 'flex',
       `button--${size}`,
       className
     ]);

--- a/src/elements/molecules/Alert/Alert.container.js
+++ b/src/elements/molecules/Alert/Alert.container.js
@@ -3,60 +3,59 @@ export const Alert = (el) => {
   // Alert's helper UI object
   const ui = {
     el,
-    alertTrigger: el.querySelector('.alert--trigger')
+    trigger: el.querySelector('.alert--trigger'),
+    closeIcon: el.querySelector('.alert--close-icon')
+  };
+
+  const state = {
+    isModal: el.classList.contains('alert--modal'),
+    isInline: el.classList.contains('alert--inline'),
+    isPersistent: el.classList.contains('alert--persistent-true')
   };
 
   // Alert's main init point
   const init = () => {
-    // dismiss alert
-    if (ui.el.querySelector('.alert--close-icon')) {
-      ui.el.querySelector('.alert--close-icon').addEventListener('click', () => {
-        ui.el.classList.add('alert-hidden');
-        if (ui.el.dataset.persistent) {
-          localStorage.setItem((ui.el.dataset.alert), 'alert dismissed');
-        }
-      });
+    // If we are alert modal, lets open it at page load
+    if (state.isModal) {
+      el.open(el);
     }
+
+    ui.el.addEventListener('click', (event) => {
+      const { target } = event;
+      const { classList } = target;
+
+      // Dismiss alert
+      if (target === ui.closeIcon) {
+        ui.el.classList.add('hidden');
+        ui.el.ariaHidden = true;
+
+        if (state.isPersistent) {
+          if (!el.id) {
+            console.error('Warning: You are trying to store an Alert molecule\'s state in localStorage but you have not supplied an id attribute on the <Alert> tag.'); // eslint-disable-line
+          } else {
+            localStorage.setItem(
+              el.id,
+              'alert dismissed'
+            );
+          }
+        }
+      }
+
+      // close alert modal
+      if (
+        classList.contains('alert--accept')
+        || classList.contains('alert--deny')
+      ) {
+        el.close(el);
+      }
+    });
 
     // hide alert if in localStorage
-    if (ui.el.dataset && localStorage.getItem(ui.el.dataset.alert)) {
-      if (ui.el.classList.contains('alert--inline')) {
-        ui.el.classList.add('alert-hidden');
+    if (localStorage.getItem(el.id)) {
+      if (state.isInline) {
+        el.classList.add('hidden');
+        el.ariaHidden = true;
       }
-    }
-
-    // close alert modal
-    if (ui.alertTrigger) {
-      const refModal = document.querySelector(`.modal[data-modal="${ui.alertTrigger.dataset.modal}"]`);
-      const modalButtons = refModal.querySelectorAll('.button');
-      Object.keys(modalButtons).map((i) => {
-        modalButtons[i].addEventListener('click', () => {
-          if (modalButtons[i].classList.contains('alert--accept')) {
-            refModal.close(refModal);
-          }
-          if (modalButtons[i].classList.contains('alert--deny')) {
-            refModal.close(refModal);
-          }
-        });
-        return false;
-      });
-    }
-
-    // set modal aria role attribute to alertdialog
-    if (ui.el.classList.contains('alert--modal')) {
-      const modalId = ui.el.querySelector('.button.alert--trigger').dataset.modal;
-      document.querySelector(`.modal[data-modal="${modalId}"]`).setAttribute('role', 'alertdialog');
-    }
-
-    // this is primarily for the guide to restore alert & remove from localStorage
-    if (ui.el.dataset.alert && document.querySelector(`button[data-alert="${ui.el.dataset.alert}"]`)) {
-      const restoreButton = document.querySelector(`button[data-alert="${ui.el.dataset.alert}"]`);
-      restoreButton.addEventListener('click', () => {
-        ui.el.classList.remove('alert-hidden');
-        if (localStorage.getItem(restoreButton.dataset.alert)) {
-          localStorage.removeItem(restoreButton.dataset.alert);
-        }
-      });
     }
   };
 

--- a/src/elements/molecules/Alert/Alert.css
+++ b/src/elements/molecules/Alert/Alert.css
@@ -6,24 +6,70 @@
 .alert {
 
   /* Baseline styles */
-
-  &--buttons {
-    justify-content: flex-end;
-  }
+  border-radius: 5px;
 
   /* Style variants */
   &--inline {
-    background-color: var(--color-gray-light);
-    border-radius: 5px;
-    color: var(--color-red);
-    padding: rem(16px);
-    
-    &.alert-hidden {
-      display: none;
+    .button {
+      &:before {
+        content: '';
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: var(--zindex--content);
+      }
+    }
+
+    .icon {
+      stroke-width: 2px;
+      position: relative;
+      z-index: var(--zindex--base);
     }
   }
 
-  .alert-close-btn:hover {
-    color: darkgray;
+  &--default {
+    background-color: color(var(--color-gray-light), 0.05);
+    border: 1px solid var(--color-gray);
+    color: var(--color-gray-dark);
+
+    .icon {
+      fill: var(--color-gray-dark);
+      stroke: var(--color-gray-dark);
+    }
+  }
+
+  &--error {
+    background-color: color(var(--color-red), 85);
+    border: 1px solid var(--color-red);
+    color: var(--color-red);
+
+    .icon {
+      fill: var(--color-red);
+      stroke: var(--color-red);
+    }
+  }
+
+  &--success {
+    background-color: color(var(--color-green), 80);
+    border: 1px solid var(--color-green);
+    color: var(--color-green);
+
+    .icon {
+      fill: var(--color-green);
+      stroke: var(--color-green);
+    }
+  }
+
+  &--warning {
+    background-color: color(var(--color-yellow), 95);
+    border: 1px solid color(var(--color-yellow), -0.05);
+    color: var(--color-gray-dark);
+
+    .icon {
+      fill: var(--color-gray);
+      stroke: var(--color-gray);
+    }
   }
 }

--- a/src/elements/molecules/Alert/Alert.css
+++ b/src/elements/molecules/Alert/Alert.css
@@ -43,22 +43,22 @@
   &--error {
     background-color: color(var(--color-red), 0.9);
     border: 1px solid var(--color-red);
-    color: var(--color-white);
+    color: var(--color-red);
 
     .icon {
-      fill: var(--color-white);
-      stroke: var(--color-white);
+      fill: var(--color-red);
+      stroke: var(--color-red);
     }
   }
 
   &--success {
     background-color: color(var(--color-green), 0.95);
     border: 1px solid var(--color-green);
-    color: var(--color-white);
+    color: var(--color-green);
 
     .icon {
-      fill: var(--color-white);
-      stroke: var(--color-white);
+      fill: var(--color-green);
+      stroke: var(--color-green);
     }
   }
 

--- a/src/elements/molecules/Alert/Alert.css
+++ b/src/elements/molecules/Alert/Alert.css
@@ -30,7 +30,7 @@
   }
 
   &--default {
-    background-color: color(var(--color-gray-light), 0.05);
+    background-color: color(var(--color-gray-light), 0.5);
     border: 1px solid var(--color-gray);
     color: var(--color-gray-dark);
 
@@ -41,7 +41,7 @@
   }
 
   &--error {
-    background-color: color(var(--color-red), 85);
+    background-color: color(var(--color-red), 0.9);
     border: 1px solid var(--color-red);
     color: var(--color-red);
 
@@ -52,7 +52,7 @@
   }
 
   &--success {
-    background-color: color(var(--color-green), 80);
+    background-color: color(var(--color-green), 0.95);
     border: 1px solid var(--color-green);
     color: var(--color-green);
 
@@ -63,8 +63,8 @@
   }
 
   &--warning {
-    background-color: color(var(--color-yellow), 95);
-    border: 1px solid color(var(--color-yellow), -0.05);
+    background-color: color(var(--color-yellow), 0.95);
+    border: 1px solid color(var(--color-yellow), -0.2);
     color: var(--color-gray-dark);
 
     .icon {

--- a/src/elements/molecules/Alert/Alert.css
+++ b/src/elements/molecules/Alert/Alert.css
@@ -43,22 +43,22 @@
   &--error {
     background-color: color(var(--color-red), 0.9);
     border: 1px solid var(--color-red);
-    color: var(--color-red);
+    color: var(--color-white);
 
     .icon {
-      fill: var(--color-red);
-      stroke: var(--color-red);
+      fill: var(--color-white);
+      stroke: var(--color-white);
     }
   }
 
   &--success {
     background-color: color(var(--color-green), 0.95);
     border: 1px solid var(--color-green);
-    color: var(--color-green);
+    color: var(--color-white);
 
     .icon {
-      fill: var(--color-green);
-      stroke: var(--color-green);
+      fill: var(--color-white);
+      stroke: var(--color-white);
     }
   }
 

--- a/src/elements/molecules/Alert/Alert.example.jsx
+++ b/src/elements/molecules/Alert/Alert.example.jsx
@@ -22,32 +22,56 @@
 */
 
 import Button from '@atoms/Button/Button';
-import Icon from '@atoms/Icon/Icon';
 import Heading from '@atoms/Heading/Heading';
-import Modal from '@molecules/Modal/Modal';
 import Rhythm from '@atoms/Rhythm/Rhythm';
 import Alert from './Alert';
 
 export default [{
   examples: [
     {
-      name: 'Default Inline Alert',
+      name: 'Default Inline Alerts',
       description: '',
       staticPath: '',
       component: (
-        <React.Fragment>
-          <Rhythm>
-            <Heading level="h5">Inline alert example. Refresh page after closing to rerender.</Heading>
-            <Alert variant="inline" className="flex flex--justify-content-between">
-              <div className="alert--inline-container" role="alertdialog">
-                <Heading level="h4" weight="thin">This is an inline alert!</Heading>
-              </div>
-              <Button variant="icon" className="alert--close-icon" aria-label="close alert">
-                <Icon name="close" aria-hidden="true" />
-              </Button>
-            </Alert>
-          </Rhythm>
-        </React.Fragment>
+        <Rhythm>
+          <Alert variant="default">
+            <Heading level="h4" weight="thin">Inline default style variant example!</Heading>
+          </Alert>
+
+          <Alert variant="error">
+            <Heading level="h4" weight="thin">Inline error style variant example!</Heading>
+          </Alert>
+
+          <Alert variant="success">
+            <Heading level="h4" weight="thin">Inline success style variant example!</Heading>
+          </Alert>
+
+          <Alert variant="warning">
+            <Heading level="h4" weight="thin">Inline warning style variant example!</Heading>
+          </Alert>
+        </Rhythm>
+      ),
+      notes: ''
+    }, {
+      name: 'Store state and persistently hide',
+      description: '',
+      staticPath: '',
+      component: (
+        <Rhythm>
+          <Alert
+            className="flex flex--justify-content-between"
+            persistent={true}
+            id="unslated-alert-demo"
+            variant="warning"
+          >
+            <div>
+              <Heading level="h4" weight="thin">
+                After you dismiss me, my state is stored in localStorage and I'm persitently hidden.<br />
+                Id attribute is required! Used to store the alert state in localStorage.
+              </Heading>
+            </div>
+          </Alert>
+        </Rhythm>
       ),
       notes: ''
     }, {
@@ -56,48 +80,19 @@ export default [{
       staticPath: '',
       component: (
         <React.Fragment>
-          <Alert variant="modal">
-            <Button className="alert--trigger" data-modal="alert-modal-id-01">Click me to open alert modal</Button>
-          </Alert>
-          <Modal data-modal="alert-modal-id-01" size="medium" hasOverlayClose={false} close={false} hasEscapeClose={false} title="Alert">
+          <p>You seen me at page load!</p>
+          <Alert
+            type="modal"
+            title="Alert modal example"
+          >
             <Rhythm>
-              <p>{Utils.ipsum('paragraph', 1)}</p>
-              <div className="flex alert--buttons">
+              <p>{Utils.ipsum('paragraph', 4)}</p>
+              <div className="flex flex--justify-content-end alert--buttons">
                 <Button className="alert--accept">Okay</Button>
                 <Button className="alert--deny">Nope</Button>
               </div>
             </Rhythm>
-          </Modal>
-        </React.Fragment>
-      ),
-      notes: ''
-    }, {
-      name: 'Stored in localStorage',
-      description: '',
-      staticPath: '',
-      component: (
-        <React.Fragment>
-          <Rhythm>
-            <Button className="alert--restore-button" data-alert="alert-id-01">Restore alert and remove from localStorage</Button>
-            <Alert
-              variant="inline"
-              className="flex flex--justify-content-between"
-              id="alert-id-01"
-              data-alert="alert-id-01"
-              persistent={true}
-            >
-              <div className="alert--inline-container" role="alertdialog">
-                <Heading level="h4" weight="thin">After you dismiss me, I'll be stored in localStorage!</Heading>
-              </div>
-              <Button
-                variant="icon"
-                className="alert--close-icon"
-                aria-label="close alert"
-              >
-                <Icon name="close" />
-              </Button>
-            </Alert>
-          </Rhythm>
+          </Alert>
         </React.Fragment>
       ),
       notes: ''

--- a/src/elements/molecules/Alert/Alert.example.jsx
+++ b/src/elements/molecules/Alert/Alert.example.jsx
@@ -84,6 +84,9 @@ export default [{
           <Alert
             type="modal"
             title="Alert modal example"
+            close={false}
+            hasEscapeClose={false}
+            hasOverlayClose={false}
           >
             <Rhythm>
               <p>{Utils.ipsum('paragraph', 4)}</p>

--- a/src/elements/molecules/Alert/Alert.jsx
+++ b/src/elements/molecules/Alert/Alert.jsx
@@ -2,6 +2,10 @@
   Alert messages can be used to notify the user about something special: danger, success, information or warning.
 */
 
+import Icon from '@atoms/Icon/Icon';
+import Button from '@atoms/Button/Button';
+import Modal from '@molecules/Modal/Modal';
+
 export class Alert extends React.Component {
   static propTypes = {
     /** Tag overload */
@@ -12,19 +16,20 @@ export class Alert extends React.Component {
     ]),
     /** Class stacking */
     className: PropTypes.string,
-    /** Style variants */
-    variant: PropTypes.oneOf(['inline', 'modal']),
+    /** Defines the style variants for alerts */
+    variant: PropTypes.oneOf(['default', 'error', 'success', 'warning']),
+    /** Defines if alert should be inline or modal */
+    type: PropTypes.oneOf(['inline', 'modal']),
     /** Children passed through */
     children: PropTypes.node,
-    /** Allows you to specify if alert is a modal or inline */
-    modal: PropTypes.bool,
-    /** Use local storage */
+    /** Defines if should only show alert only once or not (uses local storage) */
     persistent: PropTypes.bool
   };
 
   static defaultProps = {
+    type: 'inline',
     tagName: 'div',
-    variant: 'inline',
+    variant: 'default',
     persistent: false
   };
 
@@ -33,31 +38,59 @@ export class Alert extends React.Component {
 
   render = () => {
     const {
-      tagName: Tag,
+      type,
       className,
       variant,
-      children,
       persistent,
       ...attrs
     } = this.props;
 
+    let {
+      tagName: Tag,
+      children
+    } = this.props;
+
     const classStack = Utils.createClassStack([
       'alert',
+      `alert--${type}`,
       `alert--${variant}`,
+      `alert--persistent-${persistent}`,
+      'padding--small',
+      (type === 'inline') && 'flex flex--justify-content-between flex--align-items-center',
       className
     ]);
 
-    if (persistent) {
-      attrs['data-persistent'] = true;
+    const inlineStack = Utils.createClassStack([
+      'alert__inline-container',
+      className
+    ]);
+
+    if (type === 'modal') {
+      Tag = Modal;
+    }
+
+    if (type === 'inline') {
+      children = (
+        <div className={inlineStack} role="alertdialog">
+          {children}
+        </div>
+      );
     }
 
     return (
       <Tag
         className={classStack}
-        role="alert"
+        role={(type === 'modal') ? 'alertdialog' : 'alert'}
         {...attrs}
       >
         {children}
+        {
+          type === 'inline' && (
+            <Button variant="icon" className="alert--close-icon" aria-label="alert close button">
+              <Icon name="close" aria-hidden="true" />
+            </Button>
+          )
+        }
       </Tag>
     );
   }

--- a/src/elements/molecules/Brand/Brand.generic.css
+++ b/src/elements/molecules/Brand/Brand.generic.css
@@ -1,4 +1,4 @@
 .Theme--generic .brand {
-  background-color: var(--color-generic--blue);
+  background-color: var(--color-gray-light);
   color: var(--color-white);
 }

--- a/src/elements/molecules/Modal/Modal.container.js
+++ b/src/elements/molecules/Modal/Modal.container.js
@@ -23,7 +23,7 @@ export const Modal = (el) => {
   const handleWindowResize = () => checkHeight(ui.modal);
 
   // Open modal
-  const open = (modal, trigger) => {
+  const open = (modal, trigger = false) => {
     if (!modal || !modal.classList) { return; }
 
     if (trigger.href) {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -13,8 +13,8 @@ document.addEventListener('DOMContentLoaded', () => {
   Utils.initComponent('Expand', '.expand', Expand);
   Utils.initComponent('Accordion', '.accordion', Accordion);
   Utils.initComponent('Tabs', '.tabs', Tabs);
-  Utils.initComponent('Alert', '.alert', Alert);
   Utils.initComponent('Modal', '.modal', Modal, () => {
+    Utils.initComponent('Alert', '.alert', Alert);
     Utils.initComponent('Form', '.form', Form);
     Utils.initComponent('Input', '.input', Input);
     Utils.initComponent('Select', '.select', Select);

--- a/src/variables/colors.css
+++ b/src/variables/colors.css
@@ -11,22 +11,22 @@
 */
 
 :export {
-  --color-generic--blue: #003346;
-  --color-generic--green: #358450;
-  --color-generic--red: #a40000;
-
-  /* general colors */
+  /* General colors */
   --color-red: #fa0000;
   --color-blue: #0000fa;
+  --color-yellow: #ffff00;
+  --color-green: #008000;
 
-  /* grayscale */
+  /* Grayscale */
   --color-white: #fff;
   --color-gray-light: #dcdcdc;
   --color-gray: #8c8c8c;
   --color-gray-dark: #4c4c4c;
   --color-black: #000000;
 
-  /* text colors */
+  /* Text colors */
   --color-text--primary: var(--color-black);
   --color-text--secondary: var(--color-white);
+
+  /* Project colors */
 }


### PR DESCRIPTION
- Adds new type prop
- Moves inline and modal classing to be part of new type prop
- Makes new default, error, success and warning variants, styles and examples
- Updated the Alert modal example to open modal at page load and not have trigger
- Leaned into the type attribute to determine if tagName should be Modal or div
- Updates CSS color method to better support positive and negative color brightness changing
- Did away with data attributes in place for modal alert needing a id for it to be persistent
- Used flex and padding modifier classes in place of styles in a few areas

#236