### PR TITLE
UCL-51: List

### DIFF
--- a/build/guide/src/elements/molecules/Tabs/Tabs.Container.js
+++ b/build/guide/src/elements/molecules/Tabs/Tabs.Container.js
@@ -3,8 +3,8 @@ export const Tabs = (el) => {
   // Tabs ui helper object
   const ui = {
     el,
-    triggers: el.querySelectorAll('[data-tabs-trigger]'),
-    targets: el.querySelectorAll('[data-tabs-target]')
+    triggers: el.querySelectorAll('.guide__tabs__triggers > *'),
+    targets: el.querySelectorAll('.guide__tabs__targets > *')
   };
 
   // Sets active state of clicked tab trigger
@@ -33,6 +33,23 @@ export const Tabs = (el) => {
 
   // Tabs's main init method
   const init = () => {
+    // Setup children attributes and classing of triggers
+    Object.keys(ui.triggers).map((i) => {
+      const trigger = ui.triggers[i];
+      trigger.dataset.tabsTrigger = i;
+      trigger.classList.add('guide__tabs__trigger');
+      return false;
+    });
+
+    // Setup children attributes and classing of targets
+    Object.keys(ui.targets).map((i) => {
+      const target = ui.targets[i];
+      target.dataset.tabsTarget = i;
+      target.classList.add('guide__tabs__target');
+      target.classList.add('hide');
+      return false;
+    });
+
     show(el.dataset.default);
 
     // Event listener

--- a/build/guide/src/elements/molecules/Tabs/Tabs.css
+++ b/build/guide/src/elements/molecules/Tabs/Tabs.css
@@ -2,7 +2,7 @@
   --border-styles: 1px solid var(--color-gray);
   --tabs-bg-color: var(--color-white);
   --tabs-trigger-padding: rem(8px);
-  --tabs-target-padding: rem(16px);
+  --tabs-target-padding: rem(8px);
 }
 
 /* Baseline styles */
@@ -16,7 +16,7 @@
     display: none !important;
   }
 
-  .tabs__triggers {
+  .guide__tabs__triggers {
     @media (--medium) {
       display: flex;
     }
@@ -58,7 +58,6 @@
     /* Trigger styles */
     [data-tabs-trigger] {
       background-color: var(--tabs-bg-color);
-      border: var(--border-styles);
       cursor: pointer;
       min-width: 180px;
       padding: var(--tabs-trigger-padding);
@@ -78,7 +77,6 @@
     /* Target styles */
     [data-tabs-target] {
       background-color: var(--tabs-bg-color);
-      border: var(--border-styles);
       height: 100%;
       padding: var(--tabs-target-padding);
       position: relative;

--- a/build/guide/src/elements/molecules/Tabs/Tabs.jsx
+++ b/build/guide/src/elements/molecules/Tabs/Tabs.jsx
@@ -97,19 +97,12 @@ export class Tabs__triggers extends React.Component {
     const {
       tagName: Tag,
       variant,
+      children,
       ...attrs
     } = this.props;
 
-    let { children } = this.props;
-
-    children = Object.keys(children).map((i) => {
-      children[i].props['data-tabs-trigger'] = i;
-
-      return children[i];
-    });
-
     return (
-      <Tag className="tabs__triggers" {...attrs}>
+      <Tag className="guide__tabs__triggers" {...attrs}>
         {children}
       </Tag>
     );
@@ -142,20 +135,13 @@ export class Tabs__targets extends React.Component {
     const {
       tagName: Tag,
       variant,
+      children,
       title,
       ...attrs
     } = this.props;
 
-    let { children } = this.props;
-
-    children = Object.keys(children).map((i) => {
-      children[i].props['data-tabs-target'] = i;
-      children[i].props.className = 'hide';
-      return children[i];
-    });
-
     return (
-      <Tag className="tabs__targets" {...attrs}>
+      <Tag className="guide__tabs__targets" {...attrs}>
         {children}
       </Tag>
     );

--- a/build/guide/src/elements/organisms/Metrics/Metrics.css
+++ b/build/guide/src/elements/organisms/Metrics/Metrics.css
@@ -169,7 +169,7 @@
     font-size: rem(18px);
     font-weight: bold;
     width: 100%;
-    margin: rem(10px);
+    margin: rem(8px);
 
     sup {
       font-size: rem(14px);

--- a/build/guide/src/elements/organisms/Metrics/Metrics.jsx
+++ b/build/guide/src/elements/organisms/Metrics/Metrics.jsx
@@ -19,7 +19,7 @@ export const Metrics = () => {
 
   return (
     <Rhythm tagName="section" className={classStack}>
-      <Tabs className="card__deck" defaultTab="0" align="top" variant="metrics" justify="center">
+      <Tabs className="card__deck" defaultTab="0" align="top" justify="center">
         <Tabs__triggers>
           <Card className="tabs__trigger fall-flip tabs-state--open">
             <Card__body className="jsx-size" tagName="h2" />

--- a/src/elements/atoms/List/List.css
+++ b/src/elements/atoms/List/List.css
@@ -21,7 +21,7 @@
   }
 
   &--definition {
-    & .List__item {
+    & .list__item {
       &--term {
         font-weight: bold;
       }

--- a/src/elements/atoms/List/List.example.jsx
+++ b/src/elements/atoms/List/List.example.jsx
@@ -29,7 +29,16 @@ import {
 export default [{
   examples: [
     {
-      name: 'default',
+      name: 'Blank list',
+      component: (
+        <List variant="blank">
+          <List__item className="is-leader">Pig</List__item>
+          <List__item>Dog</List__item>
+          <List__item>Horse</List__item>
+        </List>
+      )
+    }, {
+      name: 'Unordered List (default)',
       component: (
         <List>
           <List__item>Horse</List__item>
@@ -38,7 +47,7 @@ export default [{
         </List>
       )
     }, {
-      name: 'ordered list',
+      name: 'Ordered list',
       component: (
         <List variant="ordered">
           <List__item className="is-leader">Pig</List__item>
@@ -47,7 +56,7 @@ export default [{
         </List>
       )
     }, {
-      name: 'definition list',
+      name: 'Definition list',
       component: (
         <List variant="definition">
           <List__item variant="term">Pig</List__item>
@@ -61,27 +70,13 @@ export default [{
         </List>
       )
     }, {
-      name: 'blank list',
+      name: 'Foreign tag list',
       component: (
-        <List variant="blank">
-          <List__item className="is-leader">Pig</List__item>
-          <List__item>Dog</List__item>
-          <List__item>Horse</List__item>
+        <List tagName="section">
+          <List__item tagName="div">Pig</List__item>
+          <List__item tagName="div">Dog</List__item>
+          <List__item tagName="div">Horse</List__item>
         </List>
-      )
-    }, {
-      name: 'list w/ class',
-      component: (
-        <List className="boogy-monster">
-          <List__item className="is-leader">Pig</List__item>
-          <List__item>Dog</List__item>
-          <List__item>Horse</List__item>
-        </List>
-      )
-    }, {
-      name: 'list item w/ class',
-      component: (
-        <List__item className="yahoo">Horse</List__item>
       )
     }
   ]

--- a/src/elements/atoms/List/List.jsx
+++ b/src/elements/atoms/List/List.jsx
@@ -31,10 +31,11 @@ export class List extends React.Component {
     const {
       tagName,
       className,
-      variant,
       children,
       ...attrs
     } = this.props;
+
+    let { variant } = this.props;
 
     const getTagName = () => {
       switch (variant) {
@@ -49,6 +50,11 @@ export class List extends React.Component {
     };
 
     const Tag = tagName || getTagName();
+
+    if (['ol', 'ul', 'dl'].indexOf(Tag) === -1) {
+      attrs.role = 'list';
+      variant = 'blank';
+    }
 
     const classStack = Utils.createClassStack([
       'list',
@@ -106,6 +112,10 @@ export class List__item extends React.Component {
     };
 
     const Tag = tagName || getTagName();
+
+    if (['dt', 'dd', 'li'].indexOf(Tag) === -1) {
+      attrs.role = 'listitem';
+    }
 
     const classStack = Utils.createClassStack([
       'list__item',

--- a/src/elements/molecules/Tabs/Tabs.container.js
+++ b/src/elements/molecules/Tabs/Tabs.container.js
@@ -3,8 +3,8 @@ export const Tabs = (el) => {
   // Tabs ui helper object
   const ui = {
     el,
-    triggers: el.querySelectorAll('.tabs__trigger'),
-    targets: el.querySelectorAll('.tabs__target')
+    triggers: el.querySelectorAll('.tabs__triggers > *'),
+    targets: el.querySelectorAll('.tabs__targets > *')
   };
 
   // Hide all targets
@@ -29,6 +29,25 @@ export const Tabs = (el) => {
 
   // Tabs's main init method
   const init = () => {
+    // Setup children attributes and classing of triggers
+    Object.keys(ui.triggers).map((i) => {
+      const trigger = ui.triggers[i];
+      trigger.dataset.tabsTrigger = i;
+      trigger.classList.add('tabs__trigger');
+      return false;
+    });
+
+    // Setup children attributes and classing of targets
+    Object.keys(ui.targets).map((i) => {
+      const target = ui.targets[i];
+      target.dataset.tabsTarget = i;
+      target.classList.add('tabs__target');
+      target.classList.add('hide');
+      return false;
+    });
+
+
+    // Open default tabbed section
     show(el.dataset.default);
 
     // Setup responsive data attributes

--- a/src/elements/molecules/Tabs/Tabs.jsx
+++ b/src/elements/molecules/Tabs/Tabs.jsx
@@ -104,19 +104,9 @@ export class Tabs__triggers extends React.Component {
     const {
       tagName: Tag,
       variant,
+      children,
       ...attrs
     } = this.props;
-
-    let { children } = this.props;
-
-    children = Object.keys(children).map((i) => {
-      children[i].props['data-tabs-trigger'] = i;
-      children[i].props.className = Utils.createClassStack([
-        'tabs__trigger',
-        children[i].props.className
-      ]);
-      return children[i];
-    });
 
     return (
       <Tag className="tabs__triggers" {...attrs}>
@@ -152,20 +142,9 @@ export class Tabs__targets extends React.Component {
     const {
       tagName: Tag,
       variant,
+      children,
       ...attrs
     } = this.props;
-
-    let { children } = this.props;
-
-    children = Object.keys(children).map((i) => {
-      children[i].props['data-tabs-target'] = i;
-      children[i].props.className = Utils.createClassStack([
-        'hide',
-        'tabs__target',
-        children[i].props.className
-      ]);
-      return children[i];
-    });
 
     return (
       <Tag className="tabs__targets" {...attrs}>


### PR DESCRIPTION
- Adding needed arial role attributes for foreign tag usage with list and list__items.
- Fixing tabs children manipulation error. This is done sooner here rather than later due to issue being found on tools/metrics now.
- Updated examples to show foreign tag usage and order them a tad better.
- Fixed missing definition list styles.