### PR TITLE
UCL - Expand

### DIFF
--- a/src/elements/molecules/Accordion/Accordion.css
+++ b/src/elements/molecules/Accordion/Accordion.css
@@ -24,7 +24,6 @@
       font-size: rem(16px);
       font-weight: normal;
       margin-top: rem(-1px);
-      padding: var(--trigger-padding);
     }
 
     .expand__target {

--- a/src/elements/molecules/Accordion/Accordion.example.jsx
+++ b/src/elements/molecules/Accordion/Accordion.example.jsx
@@ -29,13 +29,13 @@ export default [{
       name: 'Default styling',
       component: (
         <Accordion>
-          <Accordion__section title="Accordion section one" tabindex="0">
+          <Accordion__section title="Accordion section one" id="accordion-1">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section two" tabindex="0">
+          <Accordion__section title="Accordion section two" id="accordion-2">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section three" tabindex="0">
+          <Accordion__section title="Accordion section three" id="accordion-3">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
         </Accordion>
@@ -45,13 +45,13 @@ export default [{
       name: 'Spread styling',
       component: (
         <Accordion variant="spread">
-          <Accordion__section title="Accordion section one">
+          <Accordion__section title="Accordion section one" id="accordion-4">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section two">
+          <Accordion__section title="Accordion section two" id="accordion-5">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section three">
+          <Accordion__section title="Accordion section three" id="accordion-6">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
         </Accordion>
@@ -61,13 +61,13 @@ export default [{
       name: 'Align bottom',
       component: (
         <Accordion variant="spread">
-          <Accordion__section title="Accordion section one" align="bottom">
+          <Accordion__section title="Accordion section one" align="bottom" id="accordion-7">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section two" align="bottom">
+          <Accordion__section title="Accordion section two" align="bottom" id="accordion-8">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section three" align="bottom">
+          <Accordion__section title="Accordion section three" align="bottom" id="accordion-9">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
         </Accordion>
@@ -77,13 +77,13 @@ export default [{
       name: 'Disabled multiple sections',
       component: (
         <Accordion multi={false}>
-          <Accordion__section title="Accordion section one">
+          <Accordion__section title="Accordion section one" id="accordion-10">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section two">
+          <Accordion__section title="Accordion section two" id="accordion-11">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section three">
+          <Accordion__section title="Accordion section three" id="accordion-12">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
         </Accordion>

--- a/src/elements/molecules/Accordion/Accordion.example.jsx
+++ b/src/elements/molecules/Accordion/Accordion.example.jsx
@@ -28,14 +28,14 @@ export default [{
     {
       name: 'Default styling',
       component: (
-        <Accordion>
-          <Accordion__section title="Accordion section one" id="accordion-1">
+        <Accordion id="accordion-1">
+          <Accordion__section title="Accordion section one">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section two" id="accordion-2">
+          <Accordion__section title="Accordion section two">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section three" id="accordion-3">
+          <Accordion__section title="Accordion section three">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
         </Accordion>
@@ -44,14 +44,14 @@ export default [{
     }, {
       name: 'Spread styling',
       component: (
-        <Accordion variant="spread">
-          <Accordion__section title="Accordion section one" id="accordion-4">
+        <Accordion variant="spread" id="accordion-2">
+          <Accordion__section title="Accordion section one">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section two" id="accordion-5">
+          <Accordion__section title="Accordion section two">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section three" id="accordion-6">
+          <Accordion__section title="Accordion section three">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
         </Accordion>
@@ -60,14 +60,14 @@ export default [{
     }, {
       name: 'Align bottom',
       component: (
-        <Accordion variant="spread">
-          <Accordion__section title="Accordion section one" align="bottom" id="accordion-7">
+        <Accordion variant="spread" id="accordion-3">
+          <Accordion__section title="Accordion section one" align="bottom">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section two" align="bottom" id="accordion-8">
+          <Accordion__section title="Accordion section two" align="bottom">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section three" align="bottom" id="accordion-9">
+          <Accordion__section title="Accordion section three" align="bottom">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
         </Accordion>
@@ -76,14 +76,14 @@ export default [{
     }, {
       name: 'Disabled multiple sections',
       component: (
-        <Accordion multi={false}>
-          <Accordion__section title="Accordion section one" id="accordion-10">
+        <Accordion multi={false} id="accordion-4">
+          <Accordion__section title="Accordion section one">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section two" id="accordion-11">
+          <Accordion__section title="Accordion section two">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
-          <Accordion__section title="Accordion section three" id="accordion-12">
+          <Accordion__section title="Accordion section three">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
         </Accordion>

--- a/src/elements/molecules/Accordion/Accordion.jsx
+++ b/src/elements/molecules/Accordion/Accordion.jsx
@@ -20,7 +20,9 @@ export class Accordion extends React.Component {
     /** Children passed through */
     children: PropTypes.node,
     /** Multi allows you specify if accordion allows multiple sections open at once. */
-    multi: PropTypes.bool
+    multi: PropTypes.bool,
+    /** ID required for corresponding aria-labelledBy */
+    id: PropTypes.string
   };
 
   static defaultProps = {
@@ -39,10 +41,13 @@ export class Accordion extends React.Component {
       tagName: Tag,
       className,
       variant,
-      children,
       multi,
+      id,
       ...attrs
     } = this.props;
+
+    let { children } = this.props;
+    children = Object.keys(children).map((i) => React.cloneElement(children[i], { id: `${id}-${i}`, key: i }));
 
     const classStack = Utils.createClassStack([
       'accordion',

--- a/src/elements/molecules/Accordion/Accordion.jsx
+++ b/src/elements/molecules/Accordion/Accordion.jsx
@@ -81,7 +81,9 @@ export class Accordion__section extends React.Component {
     /** Level attribute overloads the heading tag size of a accordion section (h1-h6) */
     level: PropTypes.string,
     /** align attribute passes its value down to the expand molecule to align expanded content from top or bottom */
-    align: PropTypes.oneOf(['top', 'bottom'])
+    align: PropTypes.oneOf(['top', 'bottom']),
+    /** ID required for corresponding aria-labelledBy */
+    id: PropTypes.string
   };
 
   static defaultProps = {
@@ -98,6 +100,7 @@ export class Accordion__section extends React.Component {
       children,
       title,
       align,
+      id,
       ...attrs
     } = this.props;
 
@@ -113,6 +116,7 @@ export class Accordion__section extends React.Component {
         className={classStack}
         title={title}
         align={align}
+        id={id}
         {...attrs}
       >
         {children}

--- a/src/elements/molecules/Expand/Expand.container.js
+++ b/src/elements/molecules/Expand/Expand.container.js
@@ -12,9 +12,13 @@ export const Expand = (el) => {
       if (el.classList.contains('expand-state--open')) {
         el.classList.remove('expand-state--open');
         el.classList.add('expand-state--closed');
+        ui.trigger.ariaExpanded = false;
+        ui.target.ariaHidden = true;
       } else {
         el.classList.remove('expand-state--closed');
         el.classList.add('expand-state--open');
+        ui.trigger.ariaExpanded = true;
+        ui.target.ariaHidden = false;
       }
     });
   };

--- a/src/elements/molecules/Expand/Expand.css
+++ b/src/elements/molecules/Expand/Expand.css
@@ -1,5 +1,15 @@
+:root {
+  --trigger-padding: rem(10px) var(--target-padding);
+}
+
 .expand {
   display: flex;
+
+  &__trigger {
+    border: none;
+    padding: var(--trigger-padding);
+    text-align: start;
+  }
 
   /* states */
   &-state {

--- a/src/elements/molecules/Expand/Expand.example.jsx
+++ b/src/elements/molecules/Expand/Expand.example.jsx
@@ -29,7 +29,7 @@ export default [{
       name: 'Default state (align top)',
       component: (
         <div>
-          <Expand title="Toggle me" level="h5">
+          <Expand title="Toggle me" level="h5" id="expand-01">
             {Utils.ipsum('word', 3)}
           </Expand>
         </div>
@@ -39,7 +39,7 @@ export default [{
       name: 'Overloaded state (align top)',
       component: (
         <div>
-          <Expand title="Toggle me also" defaultState="open" level="h5">
+          <Expand title="Toggle me also" defaultState="open" level="h5" id="expand-02">
             {Utils.ipsum('word', 3)}
           </Expand>
         </div>
@@ -49,7 +49,7 @@ export default [{
       name: 'Align bottom',
       component: (
         <div>
-          <Expand title="Toggle me also" defaultState="open" level="h5" align="bottom">
+          <Expand title="Toggle me also" defaultState="open" level="h5" align="bottom" id="expand-03">
             {Utils.ipsum('word', 3)}
           </Expand>
         </div>
@@ -59,7 +59,7 @@ export default [{
       name: 'Align left',
       component: (
         <div>
-          <Expand title="Toggle me also" defaultState="open" level="h5" align="left">
+          <Expand title="Toggle me also" defaultState="open" level="h5" align="left" id="expand-04">
             {Utils.ipsum('word', 3)}
           </Expand>
         </div>
@@ -69,7 +69,7 @@ export default [{
       name: 'Align right',
       component: (
         <div>
-          <Expand title="Toggle me also" defaultState="open" level="h5" align="right">
+          <Expand title="Toggle me also" defaultState="open" level="h5" align="right" id="expand-05">
             {Utils.ipsum('word', 3)}
           </Expand>
         </div>

--- a/src/elements/molecules/Expand/Expand.jsx
+++ b/src/elements/molecules/Expand/Expand.jsx
@@ -79,8 +79,8 @@ export class Expand extends React.Component {
         className={classStack}
         {...attrs}
       >
-        <Heading tagName="button" level={level} className="expand__trigger" aria-expanded={expanded} id={id}>{title}</Heading>
-        <section className="expand__target" aria-hidden={!expanded} aria-labelledBy={id}>
+        <Heading tagName="button" level={level} className="expand__trigger" aria-expanded={expanded} id={`${id}ExpandTitle`} aria-controls={`${id}ExpandDesc`}>{title}</Heading>
+        <section className="expand__target" aria-hidden={!expanded} id={`${id}ExpandDesc`} aria-labelledBy={`${id}ExpandTitle`}>
           {children}
         </section>
       </Tag>

--- a/src/elements/molecules/Expand/Expand.jsx
+++ b/src/elements/molecules/Expand/Expand.jsx
@@ -30,7 +30,9 @@ export class Expand extends React.Component {
     /** Level defines the heading tag size (h1 - h6) of the expand trigger */
     level: PropTypes.string,
     /** Aligns expand target to be top or bottom */
-    align: PropTypes.oneOf(['top', 'bottom', 'left', 'right'])
+    align: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
+    /** Descriptive accessible ID required for corresponding aria-labelledBy */
+    id: PropTypes.string.isRequired
   };
 
   static defaultProps = {
@@ -58,6 +60,7 @@ export class Expand extends React.Component {
       defaultState,
       level,
       align,
+      id,
       ...attrs
     } = this.props;
 
@@ -69,13 +72,15 @@ export class Expand extends React.Component {
       className
     ]);
 
+    const expanded = defaultState !== 'closed';
+
     return (
       <Tag
         className={classStack}
         {...attrs}
       >
-        <Heading level={level} className="expand__trigger">{title}</Heading>
-        <section className="expand__target">
+        <Heading tagName="button" level={level} className="expand__trigger" aria-expanded={expanded} id={id}>{title}</Heading>
+        <section className="expand__target" aria-hidden={!expanded} aria-labelledBy={id}>
           {children}
         </section>
       </Tag>


### PR DESCRIPTION
**Expand**:

- Adds new ‘id’ prop
- Adds attribute  aria-expanded state to trigger
- Adds attribute aria-hidden state to target
- Adds aria-labelledby to target, which relies on and matches new id prop
- Toggle aria states
- Changes target Heading tag to button
- Removes default button styling, adds trigger padding

**Accordion**

- Adds Adds new ‘id’ prop, which will be passed into Expand
- Updates examples to include id
- Removes tabindex from default example
- Removes trigger padding