### PR TITLE
UCL-36: Headings

### DIFF
--- a/src/elements/atoms/Heading/Heading.jsx
+++ b/src/elements/atoms/Heading/Heading.jsx
@@ -45,6 +45,12 @@ export class Heading extends React.Component {
 
     const Tag = tagName || level || 'h1';
 
+    // If foreign tag, this indicates to AT that element should be treated like a heading
+    if (tagName) {
+      attrs.role = 'heading';
+      attrs['aria-level'] = level.replace(/[a-zA-Z]/g, '');
+    }
+
     const classStack = Utils.createClassStack([
       'heading',
       `heading--${weight}`,

--- a/src/elements/molecules/Accordion/Accordion.css
+++ b/src/elements/molecules/Accordion/Accordion.css
@@ -21,7 +21,6 @@
       background-color: var(--trigger-bg-color);
       border: var(--border-style);
       color: var(--color-gray-dark);
-      font-size: rem(16px);
       font-weight: normal;
       margin-top: rem(-1px);
     }

--- a/src/elements/molecules/Accordion/Accordion.example.jsx
+++ b/src/elements/molecules/Accordion/Accordion.example.jsx
@@ -45,7 +45,7 @@ export default [{
       name: 'Spread styling',
       component: (
         <Accordion variant="spread" id="accordion-2">
-          <Accordion__section title="Accordion section one">
+          <Accordion__section title="Accordion section one" level="h2">
             <p>{Utils.ipsum('paragraph', 1)}</p>
           </Accordion__section>
           <Accordion__section title="Accordion section two">

--- a/src/elements/molecules/Accordion/Accordion.jsx
+++ b/src/elements/molecules/Accordion/Accordion.jsx
@@ -104,6 +104,7 @@ export class Accordion__section extends React.Component {
       variant,
       children,
       title,
+      level,
       align,
       id,
       ...attrs
@@ -122,6 +123,7 @@ export class Accordion__section extends React.Component {
         title={title}
         align={align}
         id={id}
+        level={level}
         {...attrs}
       >
         {children}

--- a/src/elements/molecules/Expand/Expand.css
+++ b/src/elements/molecules/Expand/Expand.css
@@ -7,8 +7,10 @@
 
   &__trigger {
     border: none;
+    font-size: inherit;
     padding: var(--trigger-padding);
     text-align: start;
+    width: 100%;
   }
 
   /* states */

--- a/src/elements/molecules/Expand/Expand.jsx
+++ b/src/elements/molecules/Expand/Expand.jsx
@@ -79,8 +79,25 @@ export class Expand extends React.Component {
         className={classStack}
         {...attrs}
       >
-        <Heading tagName="button" level={level} className="expand__trigger" aria-expanded={expanded} id={`${id}ExpandTitle`} aria-controls={`${id}ExpandDesc`}>{title}</Heading>
-        <section className="expand__target" aria-hidden={!expanded} id={`${id}ExpandDesc`} aria-labelledBy={`${id}ExpandTitle`}>
+        <Heading
+          level={level}
+        >
+          <button
+            type="button"
+            className="expand__trigger"
+            aria-expanded={expanded}
+            id={`${id}ExpandTitle`}
+            aria-controls={`${id}ExpandDesc`}
+          >
+            {title}
+          </button>
+        </Heading>
+        <section
+          className="expand__target"
+          aria-hidden={!expanded}
+          id={`${id}ExpandDesc`}
+          aria-labelledBy={`${id}ExpandTitle`}
+        >
           {children}
         </section>
       </Tag>


### PR DESCRIPTION
Heading

- Automatically sets required role and aria-level attributes for Headings with foreign tags


Expand

- Separates Heading and button into individual elements
- Removse set font size from expand trigger  

Accordion
- Passes missing level prop