### PR TITLE
UCL: 27 - Divider

### DIFF
--- a/src/elements/atoms/Divider/Divider.css
+++ b/src/elements/atoms/Divider/Divider.css
@@ -1,0 +1,89 @@
+:root {
+
+  /* CSS variables */
+}
+
+.divider {
+
+  /* Baseline styles */
+  border-color: var(--color-black);
+  
+  /* Style variants */
+  &--horizontal {
+    border-top: solid;
+    margin: rem(32px) auto;
+
+    &.divider--length {
+      &-large {
+        width: 100%;
+      }
+  
+      &-medium {
+        width: 75%;
+      }
+  
+      &-medium-small {
+        width: 50%;
+      }
+  
+      &-small{
+        width: 25%;
+      }
+    }
+  }
+
+  &--vertical {
+    display: inline-block;
+    border-left: solid;
+    margin: 0 rem(32px);
+
+    &.divider--length {
+      &-large {
+        margin: 0 rem(32px);
+      }
+  
+      &-medium {
+        height: 75%;
+        margin: auto rem(32px);
+      }
+  
+      &-medium-small {
+        height: 50%;
+        margin: auto rem(32px);
+      }
+  
+      &-small{
+        height: 25%;
+        margin: auto rem(32px);
+      }
+    }
+  }
+
+  &--thickness {
+    &-small {
+      border-width: 1px;
+    }
+
+    &-medium {
+      border-width: 2px;
+    }
+
+    &-large {
+      border-width: 5px;
+    }
+  }
+
+  &--color {
+    &-red {
+      border-color: var(--color-red);
+    }
+
+    &-green {
+      border-color: var(--color-green);
+    }
+
+    &-gray {
+      border-color: var(--color-gray-light);
+    }
+  }
+}

--- a/src/elements/atoms/Divider/Divider.css
+++ b/src/elements/atoms/Divider/Divider.css
@@ -10,7 +10,7 @@
   
   /* Style variants */
   &--horizontal {
-    border-top: solid;
+    border: solid;
     margin: rem(32px) auto;
 
     &.divider--length {
@@ -34,7 +34,7 @@
 
   &--vertical {
     display: inline-block;
-    border-left: solid;
+    border: solid;
     margin: 0 rem(32px);
 
     &.divider--length {

--- a/src/elements/atoms/Divider/Divider.example.jsx
+++ b/src/elements/atoms/Divider/Divider.example.jsx
@@ -1,0 +1,122 @@
+/*
+  OPTIONS:
+  The following options are available for Component examples:
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
+
+  Example:
+    ```
+      examples: [{
+        name: 'Default styling',
+        component: (
+          <Component>Lorem ipsum</Component>
+        ),
+        options: {
+          padding: '1rem',
+          background: 'path/or/url/to/image(.jpg|.gif|.png|.svg)',
+          brightness: 0.5,
+        }
+      },
+    ```
+*/
+
+import Divider from './Divider';
+
+export default [{
+  examples: [
+    {
+      name: 'Default styling: horizontal, black, 2px',
+      description: '',
+      exports: '',
+      notes: '',
+      component: (
+        <React.Fragment>
+          <Divider />
+        </React.Fragment>
+      )
+    }, {
+      name: 'Length Variants',
+      description: '',
+      exports: '',
+      notes: '',
+      component: (
+        <React.Fragment>
+          <Divider />
+          <Divider length="medium" />
+          <Divider length="medium-small" />
+          <Divider length="small" />
+        </React.Fragment>
+      )
+    }, {
+      name: 'Thickness Variants',
+      description: '',
+      exports: '',
+      notes: '',
+      component: (
+        <React.Fragment>
+          <Divider />
+          <Divider thickness="large" />
+          <Divider thickness="small" />
+        </React.Fragment>
+      )
+    }, {
+      name: 'Color Variants',
+      description: '',
+      exports: '',
+      notes: '',
+      component: (
+        <React.Fragment>
+          <Divider color="black" />
+          <Divider color="gray" />
+          <Divider color="red" />
+          <Divider color="green" />
+        </React.Fragment>
+      )
+    }, {
+      name: 'Vertical Length Variant',
+      description: '',
+      exports: '',
+      notes: '',
+      component: (
+        <React.Fragment>
+          <div className="flex" style={{ height: '250px' }}>
+            <Divider variant="vertical" />
+            <Divider variant="vertical" length="medium" />
+            <Divider variant="vertical" length="medium-small" />
+            <Divider variant="vertical" length="small" />
+          </div>
+        </React.Fragment>
+      )
+    }, {
+      name: 'Vertical Thickness Variant',
+      description: '',
+      exports: '',
+      notes: '',
+      component: (
+        <React.Fragment>
+          <div className="flex" style={{ height: '250px' }}>
+            <Divider variant="vertical" />
+            <Divider variant="vertical" thickness="small" />
+            <Divider variant="vertical" thickness="large" />
+          </div>
+        </React.Fragment>
+      )
+    }, {
+      name: 'Vertical Color Variant',
+      description: '',
+      exports: '',
+      notes: '',
+      component: (
+        <React.Fragment>
+          <div className="flex" style={{ height: '250px' }}>
+            <Divider variant="vertical" />
+            <Divider variant="vertical" color="gray" />
+            <Divider variant="vertical" color="red" />
+            <Divider variant="vertical" color="green" />
+          </div>
+        </React.Fragment>
+      )
+    }
+  ]
+}];

--- a/src/elements/atoms/Divider/Divider.jsx
+++ b/src/elements/atoms/Divider/Divider.jsx
@@ -23,7 +23,7 @@ export class Divider extends React.Component {
   };
 
   static defaultProps = {
-    tagName: 'div',
+    tagName: 'hr',
     variant: 'horizontal',
     length: 'large',
     thickness: 'medium',
@@ -35,7 +35,7 @@ export class Divider extends React.Component {
 
   render = () => {
     const {
-      tagName: Tag,
+      tagName,
       className,
       variant,
       children,
@@ -45,6 +45,12 @@ export class Divider extends React.Component {
       color,
       ...attrs
     } = this.props;
+
+    let Tag = tagName;
+
+    if (variant === 'veritcal') {
+      Tag = 'div';
+    }
 
     const classStack = Utils.createClassStack([
       'divider',
@@ -58,6 +64,7 @@ export class Divider extends React.Component {
     return (
       <Tag
         className={classStack}
+        role="presentation"
         {...attrs}
       >
         {children}

--- a/src/elements/atoms/Divider/Divider.jsx
+++ b/src/elements/atoms/Divider/Divider.jsx
@@ -1,0 +1,69 @@
+/** Divider element is a dedicated component to give visual spacing between componentry. */
+
+export class Divider extends React.Component {
+  static propTypes = {
+    /** Tag overload */
+    tagName: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element,
+      PropTypes.func
+    ]),
+    /** Class stacking */
+    className: PropTypes.string,
+    /** Style variants */
+    variant: PropTypes.oneOf(['horizontal', 'vertical']),
+    /** Defines how wide it is across the screen */
+    length: PropTypes.oneOf(['large', 'medium', 'medium-small', 'small']),
+    /** Defines the thickness of the divider */
+    thickness: PropTypes.oneOf(['large', 'medium', 'small']),
+    /** Defines the color of the line */
+    color: PropTypes.oneOf(['black', 'gray', 'red', 'green']),
+    /** Children passed through */
+    children: PropTypes.node
+  };
+
+  static defaultProps = {
+    tagName: 'div',
+    variant: 'horizontal',
+    length: 'large',
+    thickness: 'medium',
+    color: 'black'
+  };
+
+  /** Element level options */
+  static options = {};
+
+  render = () => {
+    const {
+      tagName: Tag,
+      className,
+      variant,
+      children,
+      orientation,
+      length,
+      thickness,
+      color,
+      ...attrs
+    } = this.props;
+
+    const classStack = Utils.createClassStack([
+      'divider',
+      `divider--${variant}`,
+      `divider--color-${color}`,
+      `divider--length-${length}`,
+      `divider--thickness-${thickness}`,
+      className
+    ]);
+
+    return (
+      <Tag
+        className={classStack}
+        {...attrs}
+      >
+        {children}
+      </Tag>
+    );
+  }
+}
+
+export default Divider;

--- a/src/elements/atoms/Divider/Divider.test.jsx
+++ b/src/elements/atoms/Divider/Divider.test.jsx
@@ -1,0 +1,12 @@
+import test from 'tape';
+import { shallow } from 'enzyme';
+
+import Divider from './Divider';
+
+test('<Divider>', (t) => {
+  const component = shallow(<Divider>Hello World</Divider>);
+  t.ok(component.is('div'), 'tag name');
+  t.ok(component.is('.divider'), 'tag class');
+  t.equal(component.text(), 'Hello World', 'text');
+  t.end();
+});


### PR DESCRIPTION
- Create new Divider atom 
- Adds horizontal and vertical variants
- Adds length variants (name change from 'width')
- Adds thickness variants
- Adds color variants

I don't think we need to add any accessibility attributes for now. From what I read, the aria attribute role="separator" is only used if the separator is focusable or in a menu. 